### PR TITLE
Add poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,54 +32,64 @@ jobs:
           - 5672:5672
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
+    - name: Install poetry
+      run: pipx install poetry
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[testing]
+        poetry install --with dev
 
     - name: Run test suite
       env:
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
-      run: pytest --cov aiida_mlip --cov-append .
+      run: poetry run pytest --cov aiida_mlip --cov-append .
 
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
+
     - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[docs]
+      run: poetry install --with docs
+
     - name: Build docs
-      run: cd docs && make
+      run: cd docs && poetry run make
 
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
+
     - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[pre-commit,docs,testing]
+      run: poetry install --with pre-commit,docs,dev
+
     - name: Run pre-commit
       run: |
-        pre-commit install
-        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+        poetry run pre-commit install
+        poetry run pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,10 @@ jobs:
     - name: Install poetry
       run: pipx install poetry
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.11
 
     - name: Install python dependencies
       run: poetry install --with docs
@@ -81,10 +81,10 @@ jobs:
     - name: Install poetry
       run: pipx install poetry
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: 3.11
 
     - name: Install python dependencies
       run: poetry install --with pre-commit,docs,dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,11 +44,11 @@ jobs:
         poetry run make html
 
     - name: upload
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         # Upload entire repository
         path: './docs/build/html/.'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,19 +27,28 @@ jobs:
     container: sphinxdoc/sphinx
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
+    - name: Install poetry
+      run: |
+        apt update
+        apt upgrade -y
+        apt install -y pipx
+        pipx install poetry
+
     - name: sphinx
       run: |
-        python -m pip install sphinxcontrib-contentui furo aiida-core
-        # temp fix install the package
-        python -m pip install .
+        export PATH="$HOME/.local/bin:$PATH"
+        poetry install --with docs
         cd docs
-        make html
+        poetry run make html
+
     - name: upload
       uses: actions/upload-pages-artifact@v1
       with:
         # Upload entire repository
         path: './docs/build/html/.'
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -101,11 +101,15 @@ verdi data mlip export <PK>
 
 ## Development
 
+1. Install [poetry](https://python-poetry.org/docs/#installation)
+2. (Optional) Create a virtual environment
+3. Install `aiida-mlip` with dependencies:
+
 ```shell
-git clone https://github.com/aiidateam/aiida-mlip .
+git clone https://github.com/stfc/aiida-mlip
 cd aiida-mlip
 pip install --upgrade pip
-pip install -e .[pre-commit,testing]  # install extra dependencies
+poetry install --with pre-commit,dev,docs  # install extra dependencies
 pre-commit install  # install pre-commit hooks
 pytest -v  # discover and run all tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
-[build-system]
-# build the package with [flit](https://flit.readthedocs.io)
-requires = ["flit_core >=3.4,<4"]
-build-backend = "flit_core.buildapi"
-
-[project]
-# See https://www.python.org/dev/peps/pep-0621/
+[tool.poetry]
 name = "aiida-mlip"
-dynamic = ["version"]  # read from aiida_mlip/__init__.py
+version = "0.1.0a0"
 description = "machine learning interatomic potentials aiida plugin"
-authors = [{name = "Federica Zanca, Elliott Kasoar, Jacob Wilkins, Alin M. Elena"}]
+authors = [
+    "Federica Zanca",
+    "Elliott Kasoar",
+    "Jacob Wilkins",
+    "Alin M. Elena",
+]
+license = "LICENSE"
 readme = "README.md"
-license = {file = "LICENSE"}
+packages = [{include = "aiida_mlip"}]
 classifiers = [
     "Programming Language :: Python",
     "Intended Audience :: Science/Research",
@@ -20,49 +20,57 @@ classifiers = [
     "Framework :: AiiDA"
 ]
 keywords = ["aiida", "plugin"]
-requires-python = ">=3.9"
-dependencies = [
-    "aiida-core>=2.5,<3",
-    "voluptuous"
-]
+repository = "https://github.com/stfc/aiida-mlip/"
+documentation = "https://stfc.github.io/aiida-mlip/"
 
-[project.urls]
-Source = "https://github.com/aiidateam/aiida-mlip"
+[tool.poetry.urls]
+"Source" = "https://github.com/aiidateam/aiida-mlip"
 
-[project.optional-dependencies]
-testing = [
-    "pgtest~=1.3.1",
-    "wheel~=0.31",
-    "coverage[toml]",
-    "pytest~=6.0",
-    "pytest-cov"
-]
-pre-commit = [
-    "pre-commit~=2.2",
-    "pylint~=2.15.10"
-]
-docs = [
-    "sphinx",
-    "sphinxcontrib-contentui",
-    "sphinxcontrib-details-directive",
-    "furo",
-    "markupsafe<2.1"
-]
+[tool.poetry.dependencies]
+python = "^3.9"
+aiida-core = "^2.5"
+voluptuous = "^0.14"
 
-[project.entry-points."aiida.data"]
+[tool.poetry.group.dev.dependencies]
+coverage = {extras = ["toml"], version = ">=5.5"}
+pgtest = "^1.3.1"
+pytest = "^6.0"
+pytest-cov = "^4.1.0"
+wheel = "^0.31"
+
+[tool.poetry.group.pre-commit]
+optional = true
+[tool.poetry.group.pre-commit.dependencies]
+black = "^24.1.1"
+pre-commit = "^3.6.0"
+pylint = "^2.15.10"
+
+[tool.poetry.group.docs]
+optional = true
+[tool.poetry.group.docs.dependencies]
+furo = "^2024.1.29"
+markupsafe = "<2.1"
+sphinx = "^7.2.6"
+sphinxcontrib-contentui = "^0.2.5"
+sphinxcontrib-details-directive = "^0.1"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins] # Optional super table
+
+[tool.poetry.plugins."aiida.data"]
 "mlip" = "aiida_mlip.data:DiffParameters"
 
-[project.entry-points."aiida.calculations"]
+[tool.poetry.plugins."aiida.calculations"]
 "mlip" = "aiida_mlip.calculations:DiffCalculation"
 
-[project.entry-points."aiida.parsers"]
+[tool.poetry.plugins."aiida.parsers"]
 "mlip" = "aiida_mlip.parsers:DiffParser"
 
-[project.entry-points."aiida.cmdline.data"]
+[tool.poetry.plugins."aiida.cmdline.data"]
 "mlip" = "aiida_mlip.cli:data_cli"
-
-[tool.flit.module]
-name = "aiida_mlip"
 
 [tool.pylint.format]
 max-line-length = 125
@@ -104,7 +112,7 @@ envlist = py38
 [testenv]
 usedevelop=True
 
-[testenv:py{37,38,39,310}]
+[testenv:py{38,39,310}]
 description = Run the test suite against a python version
 extras = testing
 commands = pytest {posargs}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,12 @@ known_aiida = ['aiida']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38
+envlist = py39
 
 [testenv]
 usedevelop=True
 
-[testenv:py{38,39,310}]
+[testenv:py{39,310,311,312}]
 description = Run the test suite against a python version
 extras = testing
 commands = pytest {posargs}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ aiida-core = "^2.5"
 voluptuous = "^0.14"
 
 [tool.poetry.group.dev.dependencies]
-coverage = {extras = ["toml"], version = ">=5.5"}
-pgtest = "^1.3.1"
-pytest = "^6.0"
+coverage = {extras = ["toml"], version = "^7.4.1"}
+pgtest = "^1.3.2"
+pytest = "^8.0"
 pytest-cov = "^4.1.0"
-wheel = "^0.31"
+wheel = "^0.42"
 
 [tool.poetry.group.pre-commit]
 optional = true


### PR DESCRIPTION
Resolves #45 and #50

Updates pyproject.toml to be compatible with poetry, although I have omitted the .lock file to make this more general.

Notes:
- poetry does not currently conform to [PEP 621](https://peps.python.org/pep-0621/), so the format currently differs from most other modern pyproject.toml files, although support will be implemented [in the next major release](https://github.com/orgs/python-poetry/discussions/5833).
- We cannot use dynamic versioning with this, so now need to specify the version both in pyproject.toml and __init__.py
- Updates will be needed to replace the build/publishing, but these will be in a separate pull request

This also updates the workflows to use poetry installations where possible, bumps `actions` versions in workflows, and bumps `dev` (formerly `testing`) versions in pyproject.toml.

To do:

- [x] Update README with setup instructions 