### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status][cov-badge]][cov-link]
 [![Docs status][docs-badge]][docs-link]
 [![PyPI version][pypi-badge]][pypi-link]
+[![License][license-badge]][license-link]
 
 # aiida-mlip
 
@@ -116,11 +117,13 @@ See the [developer guide](https://stfc.github.io/aiida-mlip/developer_guide/inde
 BSD 3-Clause License
 
 
-[ci-badge]: https://github.com/stfc/aiida-mlip/workflows/ci/badge.svg?branch=main
+[ci-badge]: https://github.com/stfc/aiida-mlip/workflows/ci/badge.svg
 [ci-link]: https://github.com/stfc/aiida-mlip/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/aiida-mlip/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/aiida-mlip?branch=main
-[docs-badge]: https://readthedocs.org/projects/aiida-mlip/badge
+[docs-badge]: https://github.com/stfc/aiida-mlip/actions/workflows/pages/pages-build-deployment/badge.svg
 [docs-link]: https://stfc.github.io/aiida-mlip/
 [pypi-badge]: https://badge.fury.io/py/aiida-mlip.svg
 [pypi-link]: https://badge.fury.io/py/aiida-mlip
+[license-badge]: https://img.shields.io/badge/License-BSD_3--Clause-blue.svg
+[license-link]: https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
- Adds badge for the license
  - We might want to add compatible Python versions as well
- Changes the documentation badge from readthedocs to the workflow
  - The suggested link when you create the badge is to the [workflow](https://github.com/stfc/aiida-mlip/actions/workflows/pages/pages-build-deployment), but I linked the actual docs instead. Happy to have it either way
- Fixes the CI badge, which seems to be broken for [branch specific queries](https://github.com/orgs/community/discussions/14980)