### PR TITLE
Fix release via GitHub

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -38,6 +38,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: false
         prerelease: steps.check-version.outputs.prerelease == 'true'
+        skipIfReleaseExists: true
 
     - name: Publish to PyPI
       env:


### PR DESCRIPTION
Sets `skipIfReleaseExists` to `true`, which hopefully fixes publishing via the GitHub UI.

See: https://github.com/ncipollo/release-action/issues/267