### PR TITLE
Publish coverage to Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
         PYTEST_ADDOPTS: "--durations=0"
       run: poetry run pytest --cov aiida_mlip --cov-append .
 
+    - name: Report coverage to Coveralls
+      uses: coverallsapp/github-action@v2
+
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Resolves #60

Coveralls is now [linked to the repository](https://coveralls.io/github/stfc/aiida-mlip), so hopefully this should publish our coverage and get the badge working too.