### PR TITLE
Fix information for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ See the [developer guide](https://stfc.github.io/aiida-mlip/developer_guide/inde
 
 Contributors to this project were funded by
 
-[![PSDI](docs/source/images/psdi-100.webp)](https://www.psdi.ac.uk/)
-[![ALC](docs/source/images/alc-100.webp)](https://adalovelacecentre.ac.uk/)
-[![CoSeC](docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
+[![PSDI](https://raw.githubusercontent.com/stfc/aiida-mlip/main/docs/source/images/psdi-100.webp)](https://www.psdi.ac.uk/)
+[![ALC](https://raw.githubusercontent.com/stfc/aiida-mlip/main/docs/source/images/alc-100.webp)](https://adalovelacecentre.ac.uk/)
+[![CoSeC](https://raw.githubusercontent.com/stfc/aiida-mlip/main/docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
 
 
 [ci-badge]: https://github.com/stfc/aiida-mlip/workflows/ci/badge.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
     "Jacob Wilkins",
     "Alin M. Elena",
 ]
-license = "LICENSE"
 readme = "README.md"
 packages = [{include = "aiida_mlip"}]
 classifiers = [


### PR DESCRIPTION
Resolves #71 & #72

- Uses external links for the funding images, which should work on PyPI
- Removes `license` from pyproject.toml, as it adds no information not covered by `classifiers`, and does not correctly link to the LICENSE file  