### PR TITLE
Remove duplicate docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,7 @@
-name: aiida-mlip documentation publish
+name: docs
 
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Contributors to this project were funded by
 [ci-link]: https://github.com/stfc/aiida-mlip/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/aiida-mlip/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/aiida-mlip?branch=main
-[docs-badge]: https://github.com/stfc/aiida-mlip/actions/workflows/pages/pages-build-deployment/badge.svg
+[docs-badge]: https://github.com/stfc/aiida-mlip/actions/workflows/docs.yml/badge.svg
 [docs-link]: https://stfc.github.io/aiida-mlip/
 [pypi-badge]: https://badge.fury.io/py/aiida-mlip.svg
 [pypi-link]: https://badge.fury.io/py/aiida-mlip


### PR DESCRIPTION
The documentation in janus-core seems to be being [deployed successfully](https://github.com/stfc/janus-core/actions/workflows/docs.yml) via the docs.yml workflow, which is identical to the workflow in this repository, so I don't think we need the `Deploy from branch` source for pages, which triggers an additional [pages-build-deployment](https://github.com/stfc/aiida-mlip/actions/workflows/pages/pages-build-deployment) to run.

This also removes on pull request as a trigger, as it's disabled through `if: github.ref == 'refs/heads/main'` anyway, and updates the badge to use the `docs` Action rather than `pages-build-deployment`.