### PR TITLE
Fix tox for poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.lock
 *.pyc
 *.swo
 *.swp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ coverage = {extras = ["toml"], version = "^7.4.1"}
 pgtest = "^1.3.2"
 pytest = "^8.0"
 pytest-cov = "^4.1.0"
+tox = "^4.12.1"
 wheel = "^0.42"
 
 [tool.poetry.group.pre-commit]
@@ -102,28 +103,3 @@ line_length = 120
 force_sort_within_sections = true
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'AIIDA', 'FIRSTPARTY', 'LOCALFOLDER']
 known_aiida = ['aiida']
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py39
-
-[testenv]
-usedevelop=True
-
-[testenv:py{39,310,311,312}]
-description = Run the test suite against a python version
-extras = testing
-commands = pytest {posargs}
-
-[testenv:pre-commit]
-description = Run the pre-commit checks
-extras = pre-commit
-commands = pre-commit run {posargs}
-
-[testenv:docs]
-description = Build the documentation
-extras = docs
-commands = sphinx-build -nW --keep-going -b html {posargs} docs/source docs/build/html
-commands_post = echo "open file://{toxinidir}/docs/build/html/index.html"
-"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py311
+
+[testenv]
+usedevelop=True
+
+[testenv:py{39,310,311,312}]
+description = Run the test suite against Python versions
+allowlist_externals = poetry
+commands_pre = poetry install --no-root --sync
+commands = poetry run pytest --cov aiida_mlip --import-mode importlib
+
+[testenv:pre-commit]
+description = Run the pre-commit checks
+allowlist_externals = poetry
+commands_pre = poetry install --no-root --sync
+commands = poetry run pre-commit run {posargs} --all-files
+
+[testenv:docs]
+description = Build the documentation
+allowlist_externals = poetry, echo
+commands_pre = poetry install --no-root --sync
+commands = poetry run sphinx-build -nW --keep-going -b html {posargs} docs/source docs/build/html
+commands_post = echo "open file://{toxinidir}/docs/build/html/index.html"


### PR DESCRIPTION
Resolves #41

Fixes testing via tox, as our pyproject.toml does not have `extras`.

We need to use poetry to install the grouped dependencies (e.g. `[tool.poetry.group.dev.dependencies]`, as these cannot be resolved by pip.

See similarly: https://github.com/stfc/janus-core/pull/27

Also:
- Bumps the default Python to 3.11 to match CI
- Moves the tox.ini into its own file
- Adds *.lock to avoid adding poetry.lock, to keep this library general 