### PR TITLE
Fix publishing to coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,18 @@ jobs:
 
     - name: Report coverage to Coveralls
       uses: coverallsapp/github-action@v2
+      with:
+        parallel: true
+        flag-name: run-${{ matrix.python-version }}
+
+  coverage:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
From janus-core, it seems that publishing to coveralls can fail, which may be caused by the matrix jobs finish at sufficiently different times.

This can hopefully be fixed through specifying a parallel build. See: https://docs.coveralls.io/parallel-builds