### PR TITLE
Fix pytest and tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,12 @@ jobs:
       run: |
         poetry env use ${{ matrix.python-version }}
         poetry install --with dev
-        echo "JANUS_PATH=$(poetry run which janus)" >> $GITHUB_ENV
 
     - name: Run test suite
 
       env:
         # show timings of test
         PYTEST_ADDOPTS: "--durations=0"
-        JANUS_PATH: ${{ env.JANUS_PATH }}
       run: poetry run pytest --cov aiida_mlip --cov-append .
 
     - name: Report coverage to Coveralls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:plumpy:",
     "ignore::DeprecationWarning:yaml:",
 ]
+pythonpath = ["."]
 
 [tool.coverage.run]
 # Configuration of [coverage.py](https://coverage.readthedocs.io)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 import os
 from pathlib import Path
+import shutil
 
 import pytest
 
@@ -93,7 +94,7 @@ def janus_code(aiida_local_code_factory):
     `Code`
         The janus code instance.
     """
-    janus_path = os.environ.get("JANUS_PATH")
+    janus_path = shutil.which("janus") or os.environ.get("JANUS_PATH")
     return aiida_local_code_factory(executable=janus_path, entry_point="janus.sp")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ description = Run the test suite against Python versions
 allowlist_externals = poetry, sh
 commands_pre = poetry install --no-root --sync
 # Export path to janus executable installed in tox environment before running pytest
-commands = sh -c 'export JANUS_PATH=$(which janus); exec "$@"' _ poetry run pytest --cov aiida_mlip --import-mode importlib
+commands = sh -c 'export JANUS_PATH=$(which janus); exec "$@"' _ poetry run pytest {posargs} --cov aiida_mlip --import-mode importlib
 
 [testenv:pre-commit]
 description = Run the pre-commit checks

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,9 @@ usedevelop=True
 
 [testenv:py{39,310,311,312}]
 description = Run the test suite against Python versions
-allowlist_externals = poetry, sh
+allowlist_externals = poetry
 commands_pre = poetry install --no-root --sync
-# Export path to janus executable installed in tox environment before running pytest
-commands = sh -c 'export JANUS_PATH=$(which janus); exec "$@"' _ poetry run pytest {posargs} --cov aiida_mlip --import-mode importlib
+commands = poetry run pytest {posargs} --cov aiida_mlip --import-mode importlib
 
 [testenv:pre-commit]
 description = Run the pre-commit checks


### PR DESCRIPTION
- Fixes potential errors if utility modules are added to `tests`
- Fixes pytest error if `JANUS_PATH` is not set but janus is in the PATH
- Allows arguments to be passed to pytest via tox e.g. specifying specific tests to run 