### PR TITLE
Fix option names

### DIFF
--- a/examples/calculations/submit_geomopt.py
+++ b/examples/calculations/submit_geomopt.py
@@ -27,7 +27,7 @@ def geomopt(params: dict) -> None:
     structure = load_structure(params["struct"])
 
     # Select model to use
-    model = load_model(params["model"], params["architecture"])
+    model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
     geomoptCalculation = CalculationFactory("janus.opt")
@@ -36,12 +36,12 @@ def geomopt(params: dict) -> None:
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},
         "code": params["code"],
-        "architecture": Str(params["architecture"]),
-        "structure": structure,
+        "arch": Str(params["arch"]),
+        "struct": structure,
         "model": model,
         "precision": Str(params["precision"]),
         "device": Str(params["device"]),
-        "max_force": Float(params["max_force"]),
+        "fmax": Float(params["fmax"]),
         "vectors_only": Bool(params["vectors_only"]),
         "fully_opt": Bool(params["fully_opt"]),
         "opt_kwargs": Dict({"restart": "rest.pkl"}),
@@ -70,7 +70,7 @@ def geomopt(params: dict) -> None:
     help="Specify path or url of the model to use",
 )
 @click.option(
-    "--architecture",
+    "--arch",
     default="mace_mp",
     type=str,
     help="MLIP architecture to use for calculations.",
@@ -81,9 +81,7 @@ def geomopt(params: dict) -> None:
 @click.option(
     "--precision", default="float64", type=str, help="Chosen level of precision."
 )
-@click.option(
-    "--max_force", default=0.1, type=float, help="Maximum force for convergence."
-)
+@click.option("--fmax", default=0.1, type=float, help="Maximum force for convergence.")
 @click.option(
     "--vectors_only",
     default=False,
@@ -103,10 +101,10 @@ def cli(
     codelabel,
     struct,
     model,
-    architecture,
+    arch,
     device,
     precision,
-    max_force,
+    fmax,
     vectors_only,
     fully_opt,
     steps,
@@ -123,10 +121,10 @@ def cli(
         "code": code,
         "struct": struct,
         "model": model,
-        "architecture": architecture,
+        "arch": arch,
         "device": device,
         "precision": precision,
-        "max_force": max_force,
+        "fmax": fmax,
         "vectors_only": vectors_only,
         "fully_opt": fully_opt,
         "steps": steps,

--- a/examples/calculations/submit_md.py
+++ b/examples/calculations/submit_md.py
@@ -29,7 +29,7 @@ def MD(params: dict) -> None:
     structure = load_structure(params["struct"])
 
     # Select model to use
-    model = load_model(params["model"], params["architecture"])
+    model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
     MDCalculation = CalculationFactory("janus.md")
@@ -38,7 +38,7 @@ def MD(params: dict) -> None:
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},
         "code": params["code"],
-        "arch": Str(params["architecture"]),
+        "arch": Str(params["arch"]),
         "struct": structure,
         "model": model,
         "precision": Str(params["precision"]),
@@ -69,7 +69,7 @@ def MD(params: dict) -> None:
     help="Specify path or url of the model to use",
 )
 @click.option(
-    "--architecture",
+    "--arch",
     default="mace_mp",
     type=str,
     help="MLIP architecture to use for calculations.",
@@ -90,7 +90,7 @@ def MD(params: dict) -> None:
     help="String containing a dictionary with other md parameters",
 )
 def cli(
-    codelabel, struct, model, architecture, device, precision, ensemble, md_dict_str
+    codelabel, struct, model, arch, device, precision, ensemble, md_dict_str
 ) -> None:
     """Click interface."""
     # pylint: disable=too-many-arguments
@@ -105,7 +105,7 @@ def cli(
         "code": code,
         "struct": struct,
         "model": model,
-        "architecture": architecture,
+        "arch": arch,
         "device": device,
         "precision": precision,
         "ensemble": ensemble,

--- a/examples/calculations/submit_singlepoint.py
+++ b/examples/calculations/submit_singlepoint.py
@@ -37,7 +37,7 @@ def singlepoint(params: dict) -> None:
         "metadata": {"options": {"resources": {"num_machines": 1}}},
         "code": params["code"],
         "arch": Str(params["arch"]),
-        "structure": structure,
+        "struct": structure,
         "model": model,
         "precision": Str(params["precision"]),
         "device": Str(params["device"]),

--- a/examples/calculations/submit_singlepoint.py
+++ b/examples/calculations/submit_singlepoint.py
@@ -27,7 +27,7 @@ def singlepoint(params: dict) -> None:
     structure = load_structure(params["struct"])
 
     # Select model to use
-    model = load_model(params["model"], params["architecture"])
+    model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
     singlePointCalculation = CalculationFactory("janus.sp")
@@ -36,7 +36,7 @@ def singlepoint(params: dict) -> None:
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},
         "code": params["code"],
-        "architecture": Str(params["architecture"]),
+        "arch": Str(params["arch"]),
         "structure": structure,
         "model": model,
         "precision": Str(params["precision"]),
@@ -65,7 +65,7 @@ def singlepoint(params: dict) -> None:
     help="Specify path or url of the model to use",
 )
 @click.option(
-    "--architecture",
+    "--arch",
     default="mace_mp",
     type=str,
     help="MLIP architecture to use for calculations.",
@@ -76,7 +76,7 @@ def singlepoint(params: dict) -> None:
 @click.option(
     "--precision", default="float64", type=str, help="Chosen level of precision."
 )
-def cli(codelabel, struct, model, architecture, device, precision) -> None:
+def cli(codelabel, struct, model, arch, device, precision) -> None:
     # pylint: disable=too-many-arguments
     """Click interface."""
     try:
@@ -89,7 +89,7 @@ def cli(codelabel, struct, model, architecture, device, precision) -> None:
         "code": code,
         "struct": struct,
         "model": model,
-        "architecture": architecture,
+        "arch": arch,
         "device": device,
         "precision": precision,
     }


### PR DESCRIPTION
Based on @federicazanca's changes, updates `architecture` -> `arch`, `structure` -> `struct`, and `max_force` -> `fmax`, matching janus options.