### PR TITLE
add model is None in the input options

### DIFF
--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -219,11 +219,15 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
         model_path = None
         if "model" in self.inputs and self.inputs.model is not None:
             model_path = self.inputs.model.filepath
+        # Raising error if model is None
+        elif "model" in self.inputs and self.inputs.model is None:
+            raise ValueError("Model cannot be None")
         else:
             if "config" in self.inputs and "model" in self.inputs.config:
                 model_path = None
             else:
                 if "arch" in self.inputs:
+                    # if model is not given (which is different than it being None)
                     model_path = ModelData.download(
                         "https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",  # pylint: disable=line-too-long
                         architecture,

--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -217,11 +217,11 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
             cmd_line["arch"] = architecture
 
         model_path = None
-        if "model" in self.inputs and self.inputs.model is not None:
+        if "model" in self.inputs:
+            # Raise error if model is None
+            if self.inputs.model is None:
+                raise ValueError("Model cannot be None")
             model_path = self.inputs.model.filepath
-        # Raising error if model is None
-        elif "model" in self.inputs and self.inputs.model is None:
-            raise ValueError("Model cannot be None")
         else:
             if "config" in self.inputs and "model" in self.inputs.config:
                 model_path = None

--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -217,7 +217,7 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
             cmd_line["arch"] = architecture
 
         model_path = None
-        if "model" in self.inputs:
+        if "model" in self.inputs and self.inputs.model is not None:
             model_path = self.inputs.model.filepath
         else:
             if "config" in self.inputs and "model" in self.inputs.config:

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -40,7 +40,11 @@ def load_model(
         The loaded model.
     """
     if model is None:
-        loaded_model = None
+        loaded_model = ModelData.download(
+            "https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",  # pylint: disable=line-too-long
+            architecture,
+            cache_dir=cache_dir,
+        )
     elif (file_path := Path(model)).is_file():
         loaded_model = ModelData.local_file(file_path, architecture=architecture)
     else:

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -24,7 +24,7 @@ def load_model(
 
     If the string represents a file path, the model will be loaded from that path.
     If it's a URL, the model will be downloaded from the specified location.
-    If the inoput model is None it returns a default model corresponding to the
+    If the input model is None it returns a default model corresponding to the
     default used in the Calcjobs.
 
     Parameters

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -23,12 +23,14 @@ def load_model(
     Load a model from a file path or URL.
 
     If the string represents a file path, the model will be loaded from that path.
-    Otherwise, the model will be downloaded from the specified location.
+    If it's a URL, the model will be downloaded from the specified location.
+    If the inoput model is None it returns a default model corresponding to the
+    default used in the Calcjobs.
 
     Parameters
     ----------
     model : Optional[Union[str, Path]]
-        Model file path or a URL for downloading the model.
+        Model file path or a URL for downloading the model or None to use the default.
     architecture : str
         The architecture of the model.
     cache_dir : Optional[Union[str, Path]]


### PR DESCRIPTION
closes #118 

Instead of addressing the situation in the example file I catch when model is None inside the calcjob and in that case use a default model.

About the defaults I think I need to modify some things but that's another issue ( #114 )