### PR TITLE
Update ASE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ documentation = "https://stfc.github.io/aiida-mlip/"
 [tool.poetry.dependencies]
 python = "^3.9"
 aiida-core = "^2.5"
-ase = "^3.22.1"
+ase = "^3.23"
 voluptuous = "^0.14"
 janus-core = "^v0.5.0b0"
 

--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -91,7 +91,7 @@ def test_run_opt(model_folder, janus_code):
     assert "traj_output" in result
     assert "traj_file" in result
     assert result["traj_output"].numsteps == 3
-    assert result["final_structure"].cell[0][1] == pytest.approx(2.8442048309822)
+    assert result["final_structure"].cell[0][1] == pytest.approx(2.8438848145858)
     assert result["xyz_output"].filename == "aiida-results.xyz"
 
 


### PR DESCRIPTION
Drops support for ASE < 3.23, due to substantial API changes.

See similar required changes: https://github.com/stfc/janus-core/pull/181

I think the only unresolved test is `tests/calculations/test_singlepoint.py`, which I believe is the same as #135.

I think it might make sense to fix that here, rather than in #136, as the test passes with ASE 3.22.1.

I think the root isn't the file extension, but instead the change that I mention in https://github.com/stfc/janus-core/pull/181: it appears that with the new ASE, results are no longer saved in `Atoms.arrays`, which means that when you set `results = convert_numpy(content.todict())`, the results are not present.

However, without any file extension/format changes, the results are still there in the `calc.results` dictionary, and with @alinelena's changes, they will be in the `Atoms.info` dictionary shortly, so I think using those is the required fix, @federicazanca.
