### PR TITLE
Update geomopt option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A quick demo of how to submit a calculation using the provided example files:
 verdi daemon start     # make sure the daemon is running
 cd examples/calculations
 verdi run submit_singlepoint.py "janus@localhost" --struct "path/to/structure" --architecture mace --model "/path/to/model"    # run singlepoint calculation
-verdi run submit_geomopt.py "janus@localhost" --struct "path/to/structure" --model "path/to/model" --steps 5 --fully_opt True # run geometry optimisation
+verdi run submit_geomopt.py "janus@localhost" --struct "path/to/structure" --model "path/to/model" --steps 5 --opt_cell_fully True # run geometry optimisation
 verdi run submit_md.py "janus@localhost" --struct "path/to/structure" --model "path/to/model" --ensemble "nve" --md_dict_str "{'temp':300,'steps':4,'traj-every':3,'stats-every':1}" # run molecular dynamics
 
 verdi process list -a  # check record of calculation

--- a/aiida_mlip/calculations/geomopt.py
+++ b/aiida_mlip/calculations/geomopt.py
@@ -53,13 +53,13 @@ class GeomOpt(Singlepoint):  # numpydoc ignore=PR01
             help="Path to save optimisation frames to",
         )
         spec.input(
-            "fully_opt",
+            "opt_cell_fully",
             valid_type=Bool,
             required=False,
             help="Fully optimise the cell vectors, angles, and atomic positions",
         )
         spec.input(
-            "vectors_only",
+            "opt_cell_lengths",
             valid_type=Bool,
             required=False,
             help="Optimise cell vectors, as well as atomic positions",
@@ -116,10 +116,10 @@ class GeomOpt(Singlepoint):  # numpydoc ignore=PR01
         if "opt_kwargs" in self.inputs:
             opt_kwargs = self.inputs.opt_kwargs.get_dict()
             geom_opt_cmdline["opt-kwargs"] = opt_kwargs
-        if "fully_opt" in self.inputs:
-            geom_opt_cmdline["fully-opt"] = self.inputs.fully_opt.value
-        if "vectors_only" in self.inputs:
-            geom_opt_cmdline["vectors-only"] = self.inputs.vectors_only.value
+        if "opt_cell_fully" in self.inputs:
+            geom_opt_cmdline["opt-cell-fully"] = self.inputs.opt_cell_fully.value
+        if "opt_cell_lengths" in self.inputs:
+            geom_opt_cmdline["opt-cell-lengths"] = self.inputs.opt_cell_lengths.value
         if "fmax" in self.inputs:
             geom_opt_cmdline["fmax"] = self.inputs.fmax.value
         if "steps" in self.inputs:

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -84,7 +84,7 @@ def convert_to_nodes(dictionary: dict, convert_all: bool = False) -> dict:
         "model": lambda v: load_model(v, arch),
         "arch": Str,
         "ensemble": Str,
-        "fully_opt": Bool,
+        "opt_cell_fully": Bool,
     }
     for key, value in new_dict.items():
         if key in conv:

--- a/docs/source/user_guide/calculations.rst
+++ b/docs/source/user_guide/calculations.rst
@@ -141,7 +141,7 @@ Below is a usage example with some additional geometry optimisation parameters. 
 
 
     GeomOptCalculation = CalculationFactory("mlip.opt")
-    submit(GeomOptCalculation, code=InstalledCode, structure=StructureData, max_force=Float(0.1), vectors_only=Bool(True))
+    submit(GeomOptCalculation, code=InstalledCode, structure=StructureData, max_force=Float(0.1), opt_cell_lengths=Bool(True))
 
 
 .. note::

--- a/docs/source/user_guide/data.rst
+++ b/docs/source/user_guide/data.rst
@@ -75,7 +75,7 @@ The `store_content()` method accepts the following parameters:
     - `store_all` (bool):
         Determines whether to store all parameters or only specific ones.
         By default, it's set to `False`.
-        When set to `False`, only the key parameters relevant for the provenance graph are stored: `code`, `structure`, `model`, `architecture`, `fully_opt` (for GeomOpt), and `ensemble` (for MD).
+        When set to `False`, only the key parameters relevant for the provenance graph are stored: `code`, `structure`, `model`, `architecture`, `opt_cell_fully` (for GeomOpt), and `ensemble` (for MD).
         However, all inputs can be accessed in the config file at any time (just the config file will appear in the provenance graph as JanusConfigfile).
         If `store_all` is set to `True`, all inputs are stored, either as specific data types (e.g. the input 'struct' is recognised as a StructureData type) or as Str.
 

--- a/docs/source/user_guide/tutorial.rst
+++ b/docs/source/user_guide/tutorial.rst
@@ -63,8 +63,8 @@ The other inputs can be set up as AiiDA Str. There is a default for every input 
         "precision": Str("float64"),
         "device": Str("cpu"),
         "max_force": Float(0.1), # Specific to geometry optimisation: convergence criteria
-        "vectors_only": Bool(False), # Specific to geometry optimisation
-        "fully_opt": Bool(True), # Specific to geometry optimisation: to optimise the cell
+        "opt_cell_lengths": Bool(False), # Specific to geometry optimisation
+        "opt_cell_fully": Bool(True), # Specific to geometry optimisation: to optimise the cell
         "metadata": {"options": {"resources": {"num_machines": 1}}},
     }
 
@@ -162,14 +162,14 @@ The calculation can also be interacted with through verdi cli. Use `verdi proces
     architecture     1121  Str
     code                2  InstalledCode
     device           1123  Str
-    fully_opt        1126  Bool
+    opt_cell_fully   1126  Bool
     log_filename     1128  Str
     max_force        1124  Float
     model            1119  ModelData
     precision        1122  Str
     structure        1120  StructureData
     traj             1129  Str
-    vectors_only     1125  Bool
+    opt_cell_lengths 1125  Bool
     xyz_output_name  1127  Str
 
     Outputs            PK  Type

--- a/examples/calculations/submit_geomopt.py
+++ b/examples/calculations/submit_geomopt.py
@@ -42,8 +42,8 @@ def geomopt(params: dict) -> None:
         "precision": Str(params["precision"]),
         "device": Str(params["device"]),
         "fmax": Float(params["fmax"]),
-        "vectors_only": Bool(params["vectors_only"]),
-        "fully_opt": Bool(params["fully_opt"]),
+        "opt_cell_lengths": Bool(params["opt_cell_lengths"]),
+        "opt_cell_fully": Bool(params["opt_cell_fully"]),
         # "opt_kwargs": Dict({"restart": "rest.pkl"}),
         "steps": Int(params["steps"]),
     }
@@ -83,13 +83,13 @@ def geomopt(params: dict) -> None:
 )
 @click.option("--fmax", default=0.1, type=float, help="Maximum force for convergence.")
 @click.option(
-    "--vectors_only",
+    "--opt_cell_lengths",
     default=False,
     type=bool,
     help="Optimise cell vectors, as well as atomic positions.",
 )
 @click.option(
-    "--fully_opt",
+    "--opt_cell_fully",
     default=False,
     type=bool,
     help="Fully optimise the cell vectors, angles, and atomic positions.",
@@ -105,8 +105,8 @@ def cli(
     device,
     precision,
     fmax,
-    vectors_only,
-    fully_opt,
+    opt_cell_lengths,
+    opt_cell_fully,
     steps,
 ) -> None:
     # pylint: disable=too-many-arguments
@@ -125,8 +125,8 @@ def cli(
         "device": device,
         "precision": precision,
         "fmax": fmax,
-        "vectors_only": vectors_only,
-        "fully_opt": fully_opt,
+        "opt_cell_lengths": opt_cell_lengths,
+        "opt_cell_fully": opt_cell_fully,
         "steps": steps,
     }
 

--- a/examples/tutorials/geometry-optimisation.ipynb
+++ b/examples/tutorials/geometry-optimisation.ipynb
@@ -150,8 +150,8 @@
     "        \"precision\": Str(\"float64\"),\n",
     "        \"device\": Str(\"cpu\"),\n",
     "        \"fmax\": Float(0.1), \n",
-    "        \"vectors_only\": Bool(False), \n",
-    "        \"fully_opt\": Bool(True), \n",
+    "        \"opt_cell_lengths\": Bool(False), \n",
+    "        \"opt_cell_fully\": Bool(True), \n",
     "        \"metadata\": {\"options\": {\"resources\": {\"num_machines\": 1}}},\n",
     "    }"
    ]

--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -81,7 +81,7 @@ def test_run_opt(model_folder, janus_code):
         "struct": StructureData(ase=bulk("NaCl", "rocksalt", 5.63)),
         "model": ModelData.from_local(model_file, architecture="mace"),
         "device": Str("cpu"),
-        "fully_opt": Bool(True),
+        "opt_cell_fully": Bool(True),
         "fmax": Float(0.1),
         "steps": Int(1000),
     }


### PR DESCRIPTION
Resolves #158

Replaces `fully_opt` with `opt_cell_fully`, and `vectors_only` with `opt_cell_lengths` everywhere I could find them. Tests seem to be fixed, and the tutorial notebook now runs successfully.