### PR TITLE
Update pre-commit to use ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,36 +9,15 @@ repos:
     - id: trailing-whitespace
     - id: check-json
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.7.4
   hooks:
-  - id: pyupgrade
-    args: ["--py39-plus"]
-
-- repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-      args: ["--profile=black"]
-
-- repo: https://github.com/psf/black
-  rev: 24.1.1
-  hooks:
-    - id: black
-      args: [--line-length=88]
-
-- repo: local
-  hooks:
-  - id: pylint
-    language: system
-    types: [file, python]
-    name: pylint
-    description: "This hook runs the pylint static code analyzer"
-    exclude: &exclude_files >
-      (?x)^(
-          docs/.*|
-      )$
-    entry: pylint
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
 
 - repo: https://github.com/numpy/numpydoc
   rev: v1.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.7.4
+  rev: v0.5.7
   hooks:
     # Run the linter.
     - id: ruff

--- a/aiida_mlip/__init__.py
+++ b/aiida_mlip/__init__.py
@@ -1,5 +1,3 @@
-"""
-Machine learning interatomic potentials aiida plugin.
-"""
+"""Machine learning interatomic potentials aiida plugin."""
 
 __version__ = "0.2.1"

--- a/aiida_mlip/calculations/__init__.py
+++ b/aiida_mlip/calculations/__init__.py
@@ -1,3 +1,1 @@
-"""
-Calculations using MLIPs.
-"""
+"""Calculations using MLIPs."""

--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -185,7 +185,6 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
             message="Some output files missing or cannot be read",
         )
 
-    # pylint: disable=too-many-locals
     def prepare_for_submission(
         self, folder: aiida.common.folders.Folder
     ) -> datastructures.CalcInfo:

--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -2,13 +2,12 @@
 
 import shutil
 
-from ase.io import read, write
-
 from aiida.common import InputValidationError, datastructures
 import aiida.common.folders
 from aiida.engine import CalcJob, CalcJobProcessSpec
 import aiida.engine.processes
 from aiida.orm import SinglefileData, Str, StructureData
+from ase.io import read, write
 
 from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
@@ -203,7 +202,6 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
         aiida.common.datastructures.CalcInfo
             An instance of `aiida.common.datastructures.CalcInfo`.
         """
-
         if "struct" in self.inputs:
             structure = self.inputs.struct
         elif "config" in self.inputs and "struct" in self.inputs.config.as_dictionary:

--- a/aiida_mlip/calculations/geomopt.py
+++ b/aiida_mlip/calculations/geomopt.py
@@ -107,7 +107,6 @@ class GeomOpt(Singlepoint):  # numpydoc ignore=PR01
         aiida.common.datastructures.CalcInfo
             An instance of `aiida.common.datastructures.CalcInfo`.
         """
-
         # Call the parent class method to prepare common inputs
         calcinfo = super().prepare_for_submission(folder)
         codeinfo = calcinfo.codes_info[0]

--- a/aiida_mlip/calculations/md.py
+++ b/aiida_mlip/calculations/md.py
@@ -90,7 +90,6 @@ class MD(BaseJanus):  # numpydoc ignore=PR01
         aiida.common.datastructures.CalcInfo
             An instance of `aiida.common.datastructures.CalcInfo`.
         """
-
         # Call the parent class method to prepare common inputs
         calcinfo = super().prepare_for_submission(folder)
         codeinfo = calcinfo.codes_info[0]

--- a/aiida_mlip/calculations/singlepoint.py
+++ b/aiida_mlip/calculations/singlepoint.py
@@ -72,7 +72,6 @@ class Singlepoint(BaseJanus):  # numpydoc ignore=PR01
         print("defining outputnode")
         spec.default_output_node = "results_dict"
 
-    # pylint: disable=too-many-locals
     def prepare_for_submission(
         self, folder: aiida.common.folders.Folder
     ) -> datastructures.CalcInfo:

--- a/aiida_mlip/calculations/train.py
+++ b/aiida_mlip/calculations/train.py
@@ -145,7 +145,6 @@ class Train(CalcJob):  # numpydoc ignore=PR01
             message="Some output files missing or cannot be read",
         )
 
-    # pylint: disable=too-many-locals
     def prepare_for_submission(
         self, folder: aiida.common.folders.Folder
     ) -> datastructures.CalcInfo:

--- a/aiida_mlip/data/__init__.py
+++ b/aiida_mlip/data/__init__.py
@@ -1,3 +1,1 @@
-"""
-Data types for MLIPs calculations.
-"""
+"""Data types for MLIPs calculations."""

--- a/aiida_mlip/data/config.py
+++ b/aiida_mlip/data/config.py
@@ -3,9 +3,8 @@
 from pathlib import Path
 from typing import Any, Optional, Union
 
-import yaml
-
 from aiida.orm import Data, SinglefileData
+import yaml
 
 from aiida_mlip.helpers.converters import convert_to_nodes
 

--- a/aiida_mlip/data/model.py
+++ b/aiida_mlip/data/model.py
@@ -152,7 +152,6 @@ class ModelData(SinglefileData):
         return cls(file=file_path, architecture=architecture, filename=filename)
 
     @classmethod
-    # pylint: disable=too-many-arguments
     def from_uri(
         cls,
         uri: str,

--- a/aiida_mlip/data/model.py
+++ b/aiida_mlip/data/model.py
@@ -65,8 +65,7 @@ class ModelData(SinglefileData):
             # calculating sha in chunks rather than 1 large pass
             while data := f.read(buf_size):
                 sha256.update(data)
-        file_hash = sha256.hexdigest()
-        return file_hash
+        return sha256.hexdigest()
 
     def __init__(
         self,

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -5,10 +5,9 @@ Some helpers to convert between different formats.
 from pathlib import Path
 from typing import Union
 
+from aiida.orm import Bool, Dict, Str, StructureData, TrajectoryData, load_code
 from ase.io import read
 import numpy as np
-
-from aiida.orm import Bool, Dict, Str, StructureData, TrajectoryData, load_code
 
 from aiida_mlip.helpers.help_load import load_model, load_structure
 

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -12,7 +12,7 @@ from aiida_mlip.helpers.help_load import load_model, load_structure
 
 def convert_numpy(dictionary: dict) -> dict:
     """
-    A function to convert numpy ndarrays in dictionary into lists.
+    Convert numpy ndarrays in dictionary into lists.
 
     Parameters
     ----------
@@ -35,7 +35,7 @@ def xyz_to_aiida_traj(
     traj_file: Union[str, Path],
 ) -> tuple[StructureData, TrajectoryData]:
     """
-    A function to convert xyz trajectory file to `TrajectoryData` data type.
+    Convert xyz trajectory file to `TrajectoryData` data type.
 
     Parameters
     ----------

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -1,6 +1,4 @@
-"""
-Some helpers to convert between different formats.
-"""
+"""Some helpers to convert between different formats."""
 
 from pathlib import Path
 from typing import Union

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -35,7 +35,7 @@ def convert_numpy(dictionary: dict) -> dict:
 
 
 def xyz_to_aiida_traj(
-    traj_file: Union[str, Path]
+    traj_file: Union[str, Path],
 ) -> tuple[StructureData, TrajectoryData]:
     """
     A function to convert xyz trajectory file to `TrajectoryData` data type.

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -5,11 +5,10 @@ Helper functions for automatically loading models and strucutres as data nodes.
 from pathlib import Path
 from typing import Optional, Union
 
+from aiida.orm import StructureData, load_node
 from ase.build import bulk
 import ase.io
 import click
-
-from aiida.orm import StructureData, load_node
 
 from aiida_mlip.data.model import ModelData
 

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -40,7 +40,7 @@ def load_model(
     """
     if model is None:
         loaded_model = ModelData.from_uri(
-            "https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",  # pylint: disable=line-too-long
+            "https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",
             architecture,
             cache_dir=cache_dir,
         )

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -1,6 +1,4 @@
-"""
-Helper functions for automatically loading models and strucutres as data nodes.
-"""
+"""Helper functions for automatically loading models and strucutres as data nodes."""
 
 from pathlib import Path
 from typing import Optional, Union

--- a/aiida_mlip/parsers/__init__.py
+++ b/aiida_mlip/parsers/__init__.py
@@ -1,3 +1,1 @@
-"""
-Parsers for calculations.
-"""
+"""Parsers for calculations."""

--- a/aiida_mlip/parsers/base_parser.py
+++ b/aiida_mlip/parsers/base_parser.py
@@ -1,6 +1,4 @@
-"""
-Parsers provided by aiida_mlip.
-"""
+"""Parsers provided by aiida_mlip."""
 
 from aiida.engine import ExitCode
 from aiida.orm import SinglefileData

--- a/aiida_mlip/parsers/md_parser.py
+++ b/aiida_mlip/parsers/md_parser.py
@@ -1,6 +1,4 @@
-"""
-MD parser.
-"""
+"""MD parser."""
 
 from pathlib import Path
 

--- a/aiida_mlip/parsers/md_parser.py
+++ b/aiida_mlip/parsers/md_parser.py
@@ -4,13 +4,12 @@ MD parser.
 
 from pathlib import Path
 
-import yaml
-
 from aiida.common import exceptions
 from aiida.engine import ExitCode
 from aiida.orm import Dict, SinglefileData
 from aiida.orm.nodes.process.process import ProcessNode
 from aiida.plugins import CalculationFactory
+import yaml
 
 from aiida_mlip.calculations.md import MD
 from aiida_mlip.helpers.converters import xyz_to_aiida_traj

--- a/aiida_mlip/parsers/opt_parser.py
+++ b/aiida_mlip/parsers/opt_parser.py
@@ -1,6 +1,4 @@
-"""
-Geom optimisation parser.
-"""
+"""Geom optimisation parser."""
 
 from pathlib import Path
 

--- a/aiida_mlip/parsers/opt_parser.py
+++ b/aiida_mlip/parsers/opt_parser.py
@@ -11,7 +11,7 @@ from aiida.plugins import CalculationFactory
 from aiida_mlip.helpers.converters import xyz_to_aiida_traj
 from aiida_mlip.parsers.sp_parser import SPParser
 
-geomoptCalculation = CalculationFactory("mlip.opt")
+GeomoptCalc = CalculationFactory("mlip.opt")
 
 
 class GeomOptParser(SPParser):
@@ -52,7 +52,7 @@ class GeomOptParser(SPParser):
         """
         super().__init__(node)
 
-        if not issubclass(node.process_class, geomoptCalculation):
+        if not issubclass(node.process_class, GeomoptCalc):
             raise exceptions.ParsingError("Can only parse `GeomOpt` calculations")
 
     def parse(self, **kwargs) -> ExitCode:

--- a/aiida_mlip/parsers/sp_parser.py
+++ b/aiida_mlip/parsers/sp_parser.py
@@ -4,13 +4,12 @@ Parsers provided by aiida_mlip.
 
 from pathlib import Path
 
-from ase.io import read
-
 from aiida.common import exceptions
 from aiida.engine import ExitCode
 from aiida.orm import Dict, SinglefileData
 from aiida.orm.nodes.process.process import ProcessNode
 from aiida.plugins import CalculationFactory
+from ase.io import read
 
 from aiida_mlip.helpers.converters import convert_numpy
 from aiida_mlip.parsers.base_parser import BaseParser
@@ -74,7 +73,6 @@ class SPParser(BaseParser):
         int
             An exit code.
         """
-
         exit_code = super().parse(**kwargs)
 
         if exit_code != ExitCode(0):

--- a/aiida_mlip/parsers/sp_parser.py
+++ b/aiida_mlip/parsers/sp_parser.py
@@ -1,6 +1,4 @@
-"""
-Parsers provided by aiida_mlip.
-"""
+"""Parsers provided by aiida_mlip."""
 
 from pathlib import Path
 

--- a/aiida_mlip/parsers/sp_parser.py
+++ b/aiida_mlip/parsers/sp_parser.py
@@ -12,7 +12,7 @@ from ase.io import read
 from aiida_mlip.helpers.converters import convert_numpy
 from aiida_mlip.parsers.base_parser import BaseParser
 
-singlePointCalculation = CalculationFactory("mlip.sp")
+SinglepointCalc = CalculationFactory("mlip.sp")
 
 
 class SPParser(BaseParser):
@@ -40,7 +40,7 @@ class SPParser(BaseParser):
     Raises
     ------
     exceptions.ParsingError
-        If the ProcessNode being passed was not produced by a singlePointCalculation.
+        If the ProcessNode being passed was not produced by a SinglepointCalc.
     """
 
     def __init__(self, node: ProcessNode):
@@ -54,7 +54,7 @@ class SPParser(BaseParser):
         """
         super().__init__(node)
 
-        if not issubclass(node.process_class, singlePointCalculation):
+        if not issubclass(node.process_class, SinglepointCalc):
             raise exceptions.ParsingError("Can only parse `Singlepoint` calculations")
 
     def parse(self, **kwargs) -> int:

--- a/aiida_mlip/parsers/train_parser.py
+++ b/aiida_mlip/parsers/train_parser.py
@@ -1,6 +1,4 @@
-"""
-Parser for mlip train.
-"""
+"""Parser for mlip train."""
 
 import json
 from pathlib import Path

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,6 @@ copyright_year_string = (
     if current_year == copyright_first_year
     else f"{copyright_first_year}-{current_year}"
 )
-# pylint: disable=redefined-builtin
 copyright = f"{copyright_year_string}, {copyright_owners}. All rights reserved"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -2,32 +2,55 @@
 Developer guide
 ===============
 
+Getting started
++++++++++++++++
+
+We recommend `installing poetry <https://python-poetry.org/docs/#installation>`_
+for dependency management when developing for ``aiida-mlip``.
+
+This provides a number of useful features, including:
+
+- Dependency management (``poetry [add,update,remove]`` etc.) and organization (groups)
+- Storing the versions of all installations in a ``poetry.lock`` file, for reproducible builds
+- Improved dependency resolution
+- Virtual environment management (optional)
+- Building and publishing tools
+
+Dependencies useful for development can then be installed by running::
+
+    poetry install --with pre-commit,dev,docs
+
+
 Running the tests
 +++++++++++++++++
 
-The following will discover and run all unit test::
+Packages in the ``dev`` dependency group allow tests to be run locally using ``pytest``, by running::                                                                                                                                               pytest -v                                                                                                                                                                                                                                   Alternatively, tests can be run in separate virtual environments using ``tox``::                                                                                                                                                                    tox run -e ALL                                                                                                                                                                                                                              This will run all unit tests for multiple versions of Python, in addition to testing that the pre-commit passes, and that documentation builds, mirroring the automated tests on GitHub.                                                                                                                                                                                Individual components of the ``tox`` test suite can also be run separately, such as running only running the unit tests with Python 3.9::
 
-    pip install --upgrade pip
-    pip install -e .[testing]
-    pytest -v
+    tox run -e py39
 
-You can also run the tests in a virtual environment with `tox <https://tox.wiki/en/latest/>`_::
+See the `tox documentation <https://tox.wiki/>`_ for further options.
 
-    pip install tox tox-conda
-    tox -e py38 -- -v
 
 Automatic coding style checks
 +++++++++++++++++++++++++++++
 
-Enable enable automatic checks of code sanity and coding style::
+Packages in the ``pre-commit`` dependency group allow automatic code formatting and linting on every commit.
 
-    pip install -e .[pre-commit]
+To set this up, run::
+
     pre-commit install
 
-After this, the `black <https://black.readthedocs.io>`_ formatter,
-the `pylint <https://www.pylint.org/>`_ linter
-and the `pylint <https://www.pylint.org/>`_ code analyzer will
-run at every commit.
+After this, the `ruff linter <https://docs.astral.sh/ruff/linter/>`_, `ruff formatter <https://docs.astral.sh/ruff/formatter/>`_, and `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ (docstring style validator), will run before every commit.
+
+Rules enforced by ruff are currently set up to be comparable to:
+
+- `black <https://black.readthedocs.io>`_ (code formatter)
+- `pylint <https://www.pylint.org/>`_ (linter)
+- `pyupgrade <https://github.com/asottile/pyupgrade>`_ (syntax upgrader)
+- `isort <https://pycqa.github.io/isort/>`_ (import sorter)
+- `flake8-bugbear <https://pypi.org/project/flake8-bugbear/>`_ (bug finder)
+
+The full set of `ruff rules <https://docs.astral.sh/ruff/rules/>`_ are specified by the ``[tool.ruff]`` sections of `pyproject.toml <https://github.com/stfc/aiida-mlip/blob/main/pyproject.toml>`_.
 
 If you ever need to skip these pre-commit hooks, just use::
 
@@ -39,6 +62,7 @@ You should also keep the pre-commit hooks up to date periodically, with::
 
 Or consider using `pre-commit.ci <https://pre-commit.ci/>`_.
 
+
 Continuous integration
 ++++++++++++++++++++++
 
@@ -47,6 +71,7 @@ Continuous integration
 #. run all tests
 #. build the documentation
 #. check coding style and version number (not required to pass by default)
+
 
 Building the documentation
 ++++++++++++++++++++++++++

--- a/examples/calculations/submit_geomopt.py
+++ b/examples/calculations/submit_geomopt.py
@@ -1,11 +1,10 @@
-"""Example code for submitting geometry optimisation calculation"""
-
-import click
+"""Example code for submitting geometry optimisation calculation."""
 
 from aiida.common import NotExistent
 from aiida.engine import run_get_node
 from aiida.orm import Bool, Float, Int, Str, load_code
 from aiida.plugins import CalculationFactory
+import click
 
 from aiida_mlip.helpers.help_load import load_model, load_structure
 
@@ -23,7 +22,6 @@ def geomopt(params: dict) -> None:
     -------
     None
     """
-
     structure = load_structure(params["struct"])
 
     # Select model to use

--- a/examples/calculations/submit_geomopt.py
+++ b/examples/calculations/submit_geomopt.py
@@ -28,7 +28,7 @@ def geomopt(params: dict) -> None:
     model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
-    geomoptCalculation = CalculationFactory("mlip.opt")
+    GeomoptCalc = CalculationFactory("mlip.opt")
 
     # Define inputs
     inputs = {
@@ -47,7 +47,7 @@ def geomopt(params: dict) -> None:
     }
 
     # Run calculation
-    result, node = run_get_node(geomoptCalculation, **inputs)
+    result, node = run_get_node(GeomoptCalc, **inputs)
     print(f"Printing results from calculation: {result}")
     print(f"Printing node of calculation: {node}")
 

--- a/examples/calculations/submit_geomopt.py
+++ b/examples/calculations/submit_geomopt.py
@@ -107,7 +107,6 @@ def cli(
     opt_cell_fully,
     steps,
 ) -> None:
-    # pylint: disable=too-many-arguments
     """Click interface."""
     try:
         code = load_code(codelabel)
@@ -133,4 +132,4 @@ def cli(
 
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    cli()

--- a/examples/calculations/submit_md.py
+++ b/examples/calculations/submit_md.py
@@ -1,13 +1,12 @@
-"""Example code for submitting single point calculation"""
+"""Example code for submitting single point calculation."""
 
 import ast
-
-import click
 
 from aiida.common import NotExistent
 from aiida.engine import run_get_node
 from aiida.orm import Dict, Str, load_code
 from aiida.plugins import CalculationFactory
+import click
 
 from aiida_mlip.helpers.help_load import load_model, load_structure
 
@@ -25,7 +24,6 @@ def MD(params: dict) -> None:
     -------
     None
     """
-
     structure = load_structure(params["struct"])
 
     # Select model to use

--- a/examples/calculations/submit_md.py
+++ b/examples/calculations/submit_md.py
@@ -91,7 +91,6 @@ def cli(
     codelabel, struct, model, arch, device, precision, ensemble, md_dict_str
 ) -> None:
     """Click interface."""
-    # pylint: disable=too-many-arguments
     md_dict = ast.literal_eval(md_dict_str)
     try:
         code = load_code(codelabel)
@@ -115,4 +114,4 @@ def cli(
 
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    cli()

--- a/examples/calculations/submit_md.py
+++ b/examples/calculations/submit_md.py
@@ -1,4 +1,4 @@
-"""Example code for submitting single point calculation."""
+"""Example code for submitting a molecular dynamics simulation."""
 
 import ast
 
@@ -11,9 +11,9 @@ import click
 from aiida_mlip.helpers.help_load import load_model, load_structure
 
 
-def MD(params: dict) -> None:
+def md(params: dict) -> None:
     """
-    Prepare inputs and run a single point calculation.
+    Prepare inputs and run a molecular dynamics simulation.
 
     Parameters
     ----------
@@ -30,7 +30,7 @@ def MD(params: dict) -> None:
     model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
-    MDCalculation = CalculationFactory("mlip.md")
+    MDCalc = CalculationFactory("mlip.md")
 
     # Define inputs
     inputs = {
@@ -46,7 +46,7 @@ def MD(params: dict) -> None:
     }
 
     # Run calculation
-    result, node = run_get_node(MDCalculation, **inputs)
+    result, node = run_get_node(MDCalc, **inputs)
     print(f"Printing results from calculation: {result}")
     print(f"Printing node of calculation: {node}")
 
@@ -110,8 +110,8 @@ def cli(
         "md_dict": md_dict,
     }
 
-    # Submit single point
-    MD(params)
+    # Submit MD
+    md(params)
 
 
 if __name__ == "__main__":

--- a/examples/calculations/submit_md_using_config.py
+++ b/examples/calculations/submit_md_using_config.py
@@ -1,4 +1,4 @@
-"""Example code for submitting single point calculation"""
+"""Example code for submitting single point calculation."""
 
 from aiida.engine import run_get_node
 from aiida.orm import load_code

--- a/examples/calculations/submit_singlepoint.py
+++ b/examples/calculations/submit_singlepoint.py
@@ -75,7 +75,6 @@ def singlepoint(params: dict) -> None:
     "--precision", default="float64", type=str, help="Chosen level of precision."
 )
 def cli(codelabel, struct, model, arch, device, precision) -> None:
-    # pylint: disable=too-many-arguments
     """Click interface."""
     try:
         code = load_code(codelabel)
@@ -97,4 +96,4 @@ def cli(codelabel, struct, model, arch, device, precision) -> None:
 
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    cli()

--- a/examples/calculations/submit_singlepoint.py
+++ b/examples/calculations/submit_singlepoint.py
@@ -28,7 +28,7 @@ def singlepoint(params: dict) -> None:
     model = load_model(params["model"], params["arch"])
 
     # Select calculation to use
-    singlePointCalculation = CalculationFactory("mlip.sp")
+    SinglepointCalc = CalculationFactory("mlip.sp")
 
     # Define inputs
     inputs = {
@@ -42,7 +42,7 @@ def singlepoint(params: dict) -> None:
     }
 
     # Run calculation
-    result, node = run_get_node(singlePointCalculation, **inputs)
+    result, node = run_get_node(SinglepointCalc, **inputs)
     print(f"Printing results from calculation: {result}")
     print(f"Printing node of calculation: {node}")
 

--- a/examples/calculations/submit_singlepoint.py
+++ b/examples/calculations/submit_singlepoint.py
@@ -1,11 +1,10 @@
-"""Example code for submitting single point calculation"""
-
-import click
+"""Example code for submitting single point calculation."""
 
 from aiida.common import NotExistent
 from aiida.engine import run_get_node
 from aiida.orm import Str, load_code
 from aiida.plugins import CalculationFactory
+import click
 
 from aiida_mlip.helpers.help_load import load_model, load_structure
 
@@ -23,7 +22,6 @@ def singlepoint(params: dict) -> None:
     -------
         None
     """
-
     structure = load_structure(params["struct"])
 
     # Select model to use

--- a/examples/calculations/submit_train.py
+++ b/examples/calculations/submit_train.py
@@ -21,11 +21,11 @@ mlip_config = JanusConfigfile(
 )
 
 # Define calculation to run
-trainCalculation = CalculationFactory("mlip.train")
+TrainCalc = CalculationFactory("mlip.train")
 
 # Run calculation
 result, node = run_get_node(
-    trainCalculation,
+    TrainCalc,
     code=code,
     metadata=metadata,
     mlip_config=mlip_config,

--- a/examples/calculations/submit_train.py
+++ b/examples/calculations/submit_train.py
@@ -1,4 +1,4 @@
-"""Example code for submitting training calculation"""
+"""Example code for submitting training calculation."""
 
 from pathlib import Path
 

--- a/examples/calculations/submit_using_config.py
+++ b/examples/calculations/submit_using_config.py
@@ -1,4 +1,4 @@
-"""Example code for submitting single point calculation"""
+"""Example code for submitting single point calculation."""
 
 from aiida.engine import run_get_node
 from aiida.orm import load_code

--- a/examples/calculations/submit_using_config.py
+++ b/examples/calculations/submit_using_config.py
@@ -19,11 +19,11 @@ structure = load_structure("../tests/calculations/structures/NaCl.cif")
 config = JanusConfigfile("../tests/calculations/configs/config_janus.yaml")
 
 # Define calculation to run
-singlePointCalculation = CalculationFactory("mlip.sp")
+SinglepointCalc = CalculationFactory("mlip.sp")
 
 # Run calculation
 result, node = run_get_node(
-    singlePointCalculation,
+    SinglepointCalc,
     code=code,
     struct=structure,
     metadata=metadata,

--- a/examples/tutorials/geometry-optimisation.ipynb
+++ b/examples/tutorials/geometry-optimisation.ipynb
@@ -33,12 +33,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "id": "NmNkuWExt8RE",
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial cell parameters: [[0.0, 2.815, 2.815], [2.815, 0.0, 2.815], [2.815, 2.815, 0.0]]\n",
+      "Structure's atoms sites: [<Site: kind name 'Na' @ 0.0,0.0,0.0>, <Site: kind name 'Cl' @ 2.815,0.0,0.0>]\n"
+     ]
+    }
+   ],
    "source": [
     "from aiida import load_profile\n",
     "load_profile()\n",
@@ -67,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "id": "3iGSzzNithOk",
     "tags": []
@@ -112,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "id": "mH5E3MtPtyj-",
     "tags": []
@@ -134,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "id": "_XkQgKPMtyhf",
     "tags": []
@@ -169,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "id": "XOaSjxT8tyek",
     "tags": []
@@ -178,6 +187,26 @@
    "source": [
     "from aiida.plugins import CalculationFactory\n",
     "geomoptCalc = CalculationFactory(\"mlip.opt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "aiida_mlip.calculations.geomopt.GeomOpt"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geomoptCalc"
    ]
   },
   {
@@ -479,7 +508,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv_aiida_11",
    "language": "python",
    "name": "python3"
   },
@@ -493,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python = "^3.9"
 aiida-core = "^2.6"
 ase = "^3.23.0"
 voluptuous = "^0.14"
-janus-core = "^v0.6.0b0"
+janus-core = "^0.6.5"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}
@@ -44,7 +44,7 @@ wheel = "^0.42"
 optional = true
 [tool.poetry.group.pre-commit.dependencies]
 pre-commit = "^3.6.0"
-ruff = "^0.7.4"
+ruff = "^0.5.7"
 
 [tool.poetry.group.docs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,8 @@ extend-exclude = ["conf.py", "*.ipynb"]
 target-version = "py39"
 
 [tool.ruff.lint]
-# Ignore complexity
-ignore = ["C901"]
+# Ignore complexity, non-lowercase
+ignore = ["C901", "N806"]
 select = [
     # flake8-bugbear
     "B",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,8 @@ wheel = "^0.42"
 [tool.poetry.group.pre-commit]
 optional = true
 [tool.poetry.group.pre-commit.dependencies]
-black = "^24.1.1"
 pre-commit = "^3.6.0"
-pylint = "^2.15.10"
+ruff = "^0.7.4"
 
 [tool.poetry.group.docs]
 optional = true
@@ -79,19 +78,6 @@ build-backend = "poetry.core.masonry.api"
 "mlip.md_parser" = "aiida_mlip.parsers.md_parser:MDParser"
 "mlip.train_parser" = "aiida_mlip.parsers.train_parser:TrainParser"
 
-[tool.black]
-line-length = 88
-
-[tool.pylint.format]
-max-line-length = 88
-
-[tool.pylint.messages_control]
-disable = [
-    "too-many-ancestors",
-    "invalid-name",
-    "duplicate-code",
-]
-
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
 python_files = "test_*.py example_*.py"
@@ -109,14 +95,6 @@ pythonpath = ["."]
 # reporting which lines of your plugin are covered by tests
 source=["aiida_mlip"]
 
-[tool.isort]
-# Configuration of [isort](https://isort.readthedocs.io)
-force_sort_within_sections = true
-line_length = 88
-profile = "black"
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'AIIDA', 'FIRSTPARTY', 'LOCALFOLDER']
-known_aiida = ['aiida']
-
 [tool.numpydoc_validation]
 # report on all checks, except the below
 checks = [
@@ -130,3 +108,41 @@ exclude = [
     ".__weakref__$",
     ".__repr__$",
 ]
+
+[tool.ruff]
+exclude = ["conf.py"]
+target-version = "py39"
+
+[tool.ruff.lint]
+# Ignore complexity
+ignore = ["C901"]
+select = [
+    # flake8-bugbear
+    "B",
+    # pylint
+    "C", "R",
+    # pydocstyle
+    "D",
+    # pycodestyle
+    "E", "W",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "I",
+    # pep8-naming
+    "N",
+    # isort
+    "UP",
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.pylint]
+max-args = 10
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ exclude = [
 ]
 
 [tool.ruff]
-exclude = ["conf.py"]
+extend-exclude = ["conf.py", "*.ipynb"]
 target-version = "py39"
 
 [tool.ruff.lint]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-""" Tests for the plugin.
+"""Tests for the plugin.
 
 Includes both tests written in unittest style (test_cli.py) and tests written
 in pytest style (test_calculations.py).

--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -2,20 +2,18 @@
 
 import subprocess
 
-from ase.build import bulk
-import pytest
-
 from aiida.common import datastructures
 from aiida.engine import run
 from aiida.orm import Bool, Float, Int, Str, StructureData
 from aiida.plugins import CalculationFactory
+from ase.build import bulk
+import pytest
 
 from aiida_mlip.data.model import ModelData
 
 
 def test_geomopt(fixture_sandbox, generate_calc_job, janus_code, model_folder):
     """Test generating geomopt calculation job."""
-
     entry_point_name = "mlip.opt"
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
@@ -71,7 +69,6 @@ def test_geomopt(fixture_sandbox, generate_calc_job, janus_code, model_folder):
 
 def test_run_opt(model_folder, janus_code):
     """Test running geomopt calculation."""
-
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},

--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -83,8 +83,8 @@ def test_run_opt(model_folder, janus_code):
         "steps": Int(1000),
     }
 
-    geomoptCalculation = CalculationFactory("mlip.opt")
-    result = run(geomoptCalculation, **inputs)
+    GeomoptCalc = CalculationFactory("mlip.opt")
+    result = run(GeomoptCalc, **inputs)
     assert "results_dict" in result
     assert "final_structure" in result
     assert "traj_output" in result
@@ -95,7 +95,7 @@ def test_run_opt(model_folder, janus_code):
 
 
 def test_example_opt(example_path):
-    """Test function to run geomopt calculation using the example file provided."""
+    """Test function to run geometry optimization using the example file provided."""
     example_file_path = example_path / "submit_geomopt.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_md.py
+++ b/tests/calculations/test_md.py
@@ -3,14 +3,13 @@
 from pathlib import Path
 import subprocess
 
-from ase.build import bulk
-from ase.io import read, write
-import pytest
-
 from aiida.common import datastructures
 from aiida.engine import run_get_node
 from aiida.orm import Dict, Str, StructureData
 from aiida.plugins import CalculationFactory
+from ase.build import bulk
+from ase.io import read, write
+import pytest
 
 from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
@@ -18,7 +17,6 @@ from aiida_mlip.data.model import ModelData
 
 def test_MD(fixture_sandbox, generate_calc_job, janus_code, model_folder):
     """Test generating MD calculation job."""
-
     entry_point_name = "mlip.md"
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
@@ -167,7 +165,6 @@ def test_MD_with_config(
 
 def test_run_md(model_folder, structure_folder, janus_code):
     """Test running molecular dynamics calculation"""
-
     model_file = model_folder / "mace_mp_small.model"
     structure_file = structure_folder / "NaCl.cif"
     inputs = {

--- a/tests/calculations/test_md.py
+++ b/tests/calculations/test_md.py
@@ -164,7 +164,7 @@ def test_MD_with_config(
 
 
 def test_run_md(model_folder, structure_folder, janus_code):
-    """Test running molecular dynamics calculation"""
+    """Test running molecular dynamics calculation."""
     model_file = model_folder / "mace_mp_small.model"
     structure_file = structure_folder / "NaCl.cif"
     inputs = {
@@ -202,9 +202,7 @@ def test_run_md(model_folder, structure_folder, janus_code):
 
 
 def test_example_md(example_path):
-    """
-    Test function to run md calculation through the use of the example file provided.
-    """
+    """Test function to run md calculation through the use of the example file provided."""
     example_file_path = example_path / "submit_md.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_md.py
+++ b/tests/calculations/test_md.py
@@ -15,7 +15,7 @@ from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
 
 
-def test_MD(fixture_sandbox, generate_calc_job, janus_code, model_folder):
+def test_md(fixture_sandbox, generate_calc_job, janus_code, model_folder):
     """Test generating MD calculation job."""
     entry_point_name = "mlip.md"
     model_file = model_folder / "mace_mp_small.model"
@@ -95,7 +95,7 @@ def test_MD(fixture_sandbox, generate_calc_job, janus_code, model_folder):
     assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
 
 
-def test_MD_with_config(
+def test_md_with_config(
     fixture_sandbox, generate_calc_job, janus_code, model_folder, config_folder
 ):
     """Test generating MD calculation job."""
@@ -187,8 +187,8 @@ def test_run_md(model_folder, structure_folder, janus_code):
         ),
     }
 
-    MDCalculation = CalculationFactory("mlip.md")
-    result, node = run_get_node(MDCalculation, **inputs)
+    MDCalc = CalculationFactory("mlip.md")
+    result, node = run_get_node(MDCalc, **inputs)
 
     assert "final_structure" in result
     assert "traj_output" in result
@@ -202,7 +202,7 @@ def test_run_md(model_folder, structure_folder, janus_code):
 
 
 def test_example_md(example_path):
-    """Test function to run md calculation through the use of the example file provided."""
+    """Test function to run MD calculation using the example file provided."""
     example_file_path = example_path / "submit_md.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_singlepoint.py
+++ b/tests/calculations/test_singlepoint.py
@@ -14,7 +14,7 @@ from aiida_mlip.data.model import ModelData
 
 
 def test_singlepoint(fixture_sandbox, generate_calc_job, janus_code, model_folder):
-    """Test generating singlepoint calculation job"""
+    """Test generating singlepoint calculation job."""
     entry_point_name = "mlip.sp"
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
@@ -63,7 +63,7 @@ def test_singlepoint(fixture_sandbox, generate_calc_job, janus_code, model_folde
 
 
 def test_sp_nostruct(fixture_sandbox, generate_calc_job, model_folder, janus_code):
-    """Test singlepoint calculation with error input"""
+    """Test singlepoint calculation with error input."""
     entry_point_name = "mlip.sp"
     model_file = model_folder / "mace_mp_small.model"
     # pylint:disable=line-too-long
@@ -80,7 +80,7 @@ def test_sp_nostruct(fixture_sandbox, generate_calc_job, model_folder, janus_cod
 
 
 def test_sp_nomodel(fixture_sandbox, generate_calc_job, config_folder, janus_code):
-    """Test singlepoint calculation with missing model"""
+    """Test singlepoint calculation with missing model."""
     entry_point_name = "mlip.sp"
 
     inputs = {
@@ -95,7 +95,7 @@ def test_sp_nomodel(fixture_sandbox, generate_calc_job, config_folder, janus_cod
 
 
 def test_sp_noarch(fixture_sandbox, generate_calc_job, config_folder, janus_code):
-    """Test singlepoint calculation with missing architecture"""
+    """Test singlepoint calculation with missing architecture."""
     entry_point_name = "mlip.sp"
 
     inputs = {
@@ -110,7 +110,7 @@ def test_sp_noarch(fixture_sandbox, generate_calc_job, config_folder, janus_code
 
 
 def test_two_arch(fixture_sandbox, generate_calc_job, model_folder, janus_code):
-    """Test singlepoint calculation with two defined architectures"""
+    """Test singlepoint calculation with two defined architectures."""
     entry_point_name = "mlip.sp"
     model_file = model_folder / "mace_mp_small.model"
 
@@ -127,7 +127,7 @@ def test_two_arch(fixture_sandbox, generate_calc_job, model_folder, janus_code):
 
 
 def test_run_sp(model_folder, janus_code):
-    """Test running singlepoint calculation"""
+    """Test running singlepoint calculation."""
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},
@@ -149,9 +149,7 @@ def test_run_sp(model_folder, janus_code):
 
 
 def test_example(example_path):
-    """
-    Test function to run md calculation through the use of the example file provided.
-    """
+    """Test function to run md calculation through the use of the example file provided."""
     example_file_path = example_path / "submit_singlepoint.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_singlepoint.py
+++ b/tests/calculations/test_singlepoint.py
@@ -2,13 +2,12 @@
 
 import subprocess
 
-from ase.build import bulk
-import pytest
-
 from aiida.common import InputValidationError, datastructures
 from aiida.engine import run
 from aiida.orm import Str, StructureData
 from aiida.plugins import CalculationFactory
+from ase.build import bulk
+import pytest
 
 from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
@@ -16,7 +15,6 @@ from aiida_mlip.data.model import ModelData
 
 def test_singlepoint(fixture_sandbox, generate_calc_job, janus_code, model_folder):
     """Test generating singlepoint calculation job"""
-
     entry_point_name = "mlip.sp"
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
@@ -154,7 +152,6 @@ def test_example(example_path):
     """
     Test function to run md calculation through the use of the example file provided.
     """
-
     example_file_path = example_path / "submit_singlepoint.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_singlepoint.py
+++ b/tests/calculations/test_singlepoint.py
@@ -66,7 +66,6 @@ def test_sp_nostruct(fixture_sandbox, generate_calc_job, model_folder, janus_cod
     """Test singlepoint calculation with error input."""
     entry_point_name = "mlip.sp"
     model_file = model_folder / "mace_mp_small.model"
-    # pylint:disable=line-too-long
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},
         "code": janus_code,

--- a/tests/calculations/test_singlepoint.py
+++ b/tests/calculations/test_singlepoint.py
@@ -139,8 +139,8 @@ def test_run_sp(model_folder, janus_code):
         "device": Str("cpu"),
     }
 
-    singlePointCalculation = CalculationFactory("mlip.sp")
-    result = run(singlePointCalculation, **inputs)
+    SinglepointCalc = CalculationFactory("mlip.sp")
+    result = run(SinglepointCalc, **inputs)
     assert "results_dict" in result
     obtained_res = result["results_dict"].get_dict()
     assert "xyz_output" in result
@@ -149,7 +149,7 @@ def test_run_sp(model_folder, janus_code):
 
 
 def test_example(example_path):
-    """Test function to run md calculation through the use of the example file provided."""
+    """Test function to run singlepoint calculation using the example file provided."""
     example_file_path = example_path / "submit_singlepoint.py"
     command = ["verdi", "run", example_file_path, "janus@localhost"]
 

--- a/tests/calculations/test_train.py
+++ b/tests/calculations/test_train.py
@@ -163,7 +163,7 @@ def test_finetune_error(fixture_sandbox, generate_calc_job, janus_code, config_f
 
 @pytest.mark.skipif(MACE_IMPORT_ERROR, reason="Requires updated version of MACE")
 def test_run_train(janus_code, config_folder):
-    """Test running train with fine-tuning calculation"""
+    """Test running train with fine-tuning calculation."""
     model_file = config_folder / "test.model"
     config_path = config_folder / "mlip_train.yml"
     config = JanusConfigfile(file=config_path)

--- a/tests/calculations/test_train.py
+++ b/tests/calculations/test_train.py
@@ -1,11 +1,10 @@
 """Tests for model train."""
 
-import pytest
-
 from aiida.common import InputValidationError, datastructures
 from aiida.engine import run
 from aiida.orm import Bool
 from aiida.plugins import CalculationFactory
+import pytest
 
 from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
@@ -21,7 +20,6 @@ except ImportError:
 
 def test_prepare_train(fixture_sandbox, generate_calc_job, janus_code, config_folder):
     """Test generating singlepoint calculation job."""
-
     entry_point_name = "mlip.train"
     config_path = config_folder / "mlip_train.yml"
     config = JanusConfigfile(file=config_path)
@@ -54,7 +52,6 @@ def test_file_error(
     fixture_sandbox, generate_calc_job, janus_code, config_folder, tmp_path
 ):
     """Test error if path for xyz is non existent."""
-
     entry_point_name = "mlip.train"
     config_path = config_folder / "mlip_train.yml"
 
@@ -81,7 +78,6 @@ def test_noname(
     fixture_sandbox, generate_calc_job, janus_code, config_folder, tmp_path
 ):
     """Test error if no 'name' keyword is given in config."""
-
     entry_point_name = "mlip.train"
     config_path = config_folder / "mlip_train.yml"
 
@@ -111,7 +107,6 @@ def test_noname(
 
 def test_prepare_tune(fixture_sandbox, generate_calc_job, janus_code, config_folder):
     """Test generating fine tuning calculation job."""
-
     model_file = config_folder / "test.model"
     entry_point_name = "mlip.train"
     config_path = config_folder / "mlip_train.yml"
@@ -152,7 +147,6 @@ def test_prepare_tune(fixture_sandbox, generate_calc_job, janus_code, config_fol
 
 def test_finetune_error(fixture_sandbox, generate_calc_job, janus_code, config_folder):
     """Test error if no model is given."""
-
     entry_point_name = "mlip.train"
     config_path = config_folder / "mlip_train.yml"
     config = JanusConfigfile(file=config_path)
@@ -170,7 +164,6 @@ def test_finetune_error(fixture_sandbox, generate_calc_job, janus_code, config_f
 @pytest.mark.skipif(MACE_IMPORT_ERROR, reason="Requires updated version of MACE")
 def test_run_train(janus_code, config_folder):
     """Test running train with fine-tuning calculation"""
-
     model_file = config_folder / "test.model"
     config_path = config_folder / "mlip_train.yml"
     config = JanusConfigfile(file=config_path)

--- a/tests/calculations/test_train.py
+++ b/tests/calculations/test_train.py
@@ -9,14 +9,6 @@ import pytest
 from aiida_mlip.data.config import JanusConfigfile
 from aiida_mlip.data.model import ModelData
 
-# this is just a temporary solution till mace gets a tag on current main.
-try:
-    from mace.cli.run_train import run as run_train  # pylint: disable=unused-import
-
-    MACE_IMPORT_ERROR = False
-except ImportError:
-    MACE_IMPORT_ERROR = True
-
 
 def test_prepare_train(fixture_sandbox, generate_calc_job, janus_code, config_folder):
     """Test generating singlepoint calculation job."""
@@ -161,7 +153,6 @@ def test_finetune_error(fixture_sandbox, generate_calc_job, janus_code, config_f
         generate_calc_job(fixture_sandbox, entry_point_name, inputs)
 
 
-@pytest.mark.skipif(MACE_IMPORT_ERROR, reason="Requires updated version of MACE")
 def test_run_train(janus_code, config_folder):
     """Test running train with fine-tuning calculation."""
     model_file = config_folder / "test.model"
@@ -177,8 +168,8 @@ def test_run_train(janus_code, config_folder):
         ),
     }
 
-    trainfinetuneCalc = CalculationFactory("mlip.train")
-    result = run(trainfinetuneCalc, **inputs)
+    FinetuneCalc = CalculationFactory("mlip.train")
+    result = run(FinetuneCalc, **inputs)
 
     assert "results_dict" in result
     obtained_res = result["results_dict"].get_dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,9 +185,7 @@ def generate_calc_job():
         process_class = CalculationFactory(entry_point_name)
         process = instantiate_process(runner, process_class, **inputs)
 
-        calc_info = process.prepare_for_submission(folder)
-
-        return calc_info
+        return process.prepare_for_submission(folder)
 
     return _generate_calc_job
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,11 @@ def clear_database_auto(aiida_profile_clean):  # pylint: disable=unused-argument
 def filepath_tests():
     """
     Return the absolute filepath of the `tests` folder.
-    .. warning: If this file moves with respect to the `tests` folder,
-        the implementation should change.
+
+    Warning
+    -------
+    If this file moves with respect to the `tests` folder, the implementation should
+    change.
 
     Parameters
     ----------
@@ -99,8 +102,7 @@ def janus_code(aiida_local_code_factory):
 @pytest.fixture
 def fixture_code(fixture_localhost):
     """
-    Return an `InstalledCode` instance configured to run calculations of a given
-    entry point on localhost.
+    Return a configured `InstalledCode` instance to run calculations on localhost.
 
     Parameters
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name,too-many-statements
 """Initialise a text database and profile for pytest."""
 
 import os
@@ -13,11 +12,11 @@ from aiida.orm import InstalledCode, load_code
 from aiida.plugins import CalculationFactory
 import pytest
 
-pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]  # pylint: disable=invalid-name
+pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clear_database_auto(aiida_profile_clean):  # pylint: disable=unused-argument
+def clear_database_auto(aiida_profile_clean):
     """Automatically clear database in between tests."""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,13 @@ import os
 from pathlib import Path
 import shutil
 
-import pytest
-
 from aiida.common import exceptions
 from aiida.common.folders import SandboxFolder
 from aiida.engine.utils import instantiate_process
 from aiida.manage.manager import get_manager
 from aiida.orm import InstalledCode, load_code
 from aiida.plugins import CalculationFactory
+import pytest
 
 pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]  # pylint: disable=invalid-name
 
@@ -54,7 +53,6 @@ def fixture_sandbox():
     SandboxFolder
         A `SandboxFolder` instance for temporary file operations.
     """
-
     with SandboxFolder() as folder:
         yield folder
 
@@ -181,7 +179,6 @@ def generate_calc_job():
         using the provided inputs, and calls `prepare_for_submission`.
         The resulting `CalcInfo` object is returned.
         """
-
         manager = get_manager()
         runner = manager.get_runner()
 
@@ -200,7 +197,8 @@ def test_folder():
     """
     Fixture to provide the path of the tests folder.
 
-    Returns:
+    Returns
+    -------
         Path: the path of the tests folder.
     """
     return Path(__file__).resolve().parent
@@ -212,7 +210,8 @@ def example_path(test_folder):
     """
     Fixture to provide the path to the example file.
 
-    Returns:
+    Returns
+    -------
         Path: The path to the example file.
     """
     return test_folder.parent / "examples" / "calculations"
@@ -223,7 +222,8 @@ def model_folder(test_folder):
     """
     Fixture to provide the path to the example file.
 
-    Returns:
+    Returns
+    -------
         Path: The path to the example file.
     """
     return test_folder / "data" / "input_files" / "mace"
@@ -234,7 +234,8 @@ def structure_folder(test_folder):
     """
     Fixture to provide the path to the example file.
 
-    Returns:
+    Returns
+    -------
         Path: The path to the example file.
     """
     return test_folder / "calculations" / "structures"
@@ -245,7 +246,8 @@ def config_folder(test_folder):
     """
     Fixture to provide the path to the example file.
 
-    Returns:
+    Returns
+    -------
         Path: The path to the example file.
     """
     return test_folder / "calculations" / "configs"

--- a/tests/data/test_config.py
+++ b/tests/data/test_config.py
@@ -1,10 +1,10 @@
-"""Test for JanusConfigfile class"""
+"""Test for JanusConfigfile class."""
 
 from aiida_mlip.data.config import JanusConfigfile
 
 
 def test_local_file(config_folder):
-    """Testing that the local file function works"""
+    """Testing that the local file function works."""
     # Construct a ModelData instance with the local file
     config_path = config_folder / "config_janus_md.yaml"
     config = JanusConfigfile(file=config_path)

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -8,7 +8,7 @@ model_path = Path(__file__).parent / "input_files" / "model_local_file.txt"
 
 
 def test_local_file():
-    """Testing that the from_local function works"""
+    """Testing that the from_local function works."""
     # Construct a ModelData instance with the local file
     absolute_path = model_path.resolve()
     model = ModelData.from_local(file=absolute_path, architecture="mace")
@@ -18,7 +18,7 @@ def test_local_file():
 
 
 def test_relativepath():
-    """Testing that the from_local function works with a relative path"""
+    """Testing that the from_local function works with a relative path."""
     # Construct a ModelData instance with the local file
     relative_path = model_path.relative_to(Path.cwd())
     model = ModelData.from_local(file=relative_path, architecture="mace")
@@ -28,7 +28,7 @@ def test_relativepath():
 
 
 def test_architecture():
-    """Testing that the architecture is read and added to attributes"""
+    """Testing that the architecture is read and added to attributes."""
     model = ModelData.from_local(
         file=model_path,
         filename="model",
@@ -59,7 +59,7 @@ def test_download_fresh_file_keep(tmp_path):
 
 
 def test_download_fresh_file(tmp_path):
-    """Test if download works and the file is only saved in the database not locally"""
+    """Test if download works and the file is only saved in the database not locally."""
     # Ensure we do not have the file cached already
     path_test = tmp_path / "mace" / "mace.model"
     path_test.unlink(missing_ok=True)

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -44,7 +44,6 @@ def test_download_fresh_file_keep(tmp_path):
     path_test.unlink(missing_ok=True)
 
     # Construct a ModelData instance downloading a non-cached file
-    # pylint:disable=line-too-long
     model = ModelData.from_uri(
         uri="https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",
         filename="mace.model",
@@ -65,7 +64,6 @@ def test_download_fresh_file(tmp_path):
     path_test.unlink(missing_ok=True)
 
     # Construct a ModelData instance downloading a non-cached file
-    # pylint:disable=line-too-long
     model = ModelData.from_uri(
         uri="https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",
         filename="mace.model",
@@ -80,7 +78,6 @@ def test_download_fresh_file(tmp_path):
 
 def test_no_download_cached_file(tmp_path):
     """Test if the caching prevents saving duplicate model in the database."""
-    # pylint:disable=line-too-long
     existing_model = ModelData.from_uri(
         uri="https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",
         filename="mace_existing.model",
@@ -88,7 +85,6 @@ def test_no_download_cached_file(tmp_path):
         architecture="mace_mp",
     )
     # Construct a ModelData instance that should use the cached file
-    # pylint:disable=line-too-long
     model = ModelData.from_uri(
         uri="https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",
         cache_dir=tmp_path,

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -80,7 +80,6 @@ def test_download_fresh_file(tmp_path):
 
 def test_no_download_cached_file(tmp_path):
     """Test if the caching prevents saving duplicate model in the database."""
-
     # pylint:disable=line-too-long
     existing_model = ModelData.from_uri(
         uri="https://github.com/stfc/janus-core/raw/main/tests/models/mace_mp_small.model",

--- a/tests/helpers/test_converters.py
+++ b/tests/helpers/test_converters.py
@@ -2,9 +2,8 @@
 
 from pathlib import Path
 
-import numpy as np
-
 from aiida.orm import StructureData, TrajectoryData
+import numpy as np
 
 from aiida_mlip.helpers.converters import convert_numpy, xyz_to_aiida_traj
 

--- a/tests/helpers/test_load.py
+++ b/tests/helpers/test_load.py
@@ -2,11 +2,10 @@
 
 from pathlib import Path
 
+from aiida.orm import StructureData
 import ase.io
 import click
 import pytest
-
-from aiida.orm import StructureData
 
 from aiida_mlip.data.model import ModelData
 from aiida_mlip.helpers.help_load import load_model, load_structure


### PR DESCRIPTION
Resolves #157

Note: There are newer versions of `ruff` (0.7.4), but these would not allow us to use the latest `janus-core`, so that needs updating first.

I've also added an ignore for `N806` (checks for the use of non-lowercase variable names in functions), as this is throwing errors about the returns from `CalculationFactory` in some, but not all, cases. This should probably be revisited at some point.

Partially resolves #156