### PR TITLE
Fix submission tests

### DIFF
--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -94,12 +94,20 @@ def test_run_opt(model_folder, janus_code):
     assert result["xyz_output"].filename == "aiida-results.xyz"
 
 
-def test_example_opt(example_path):
+def test_example_opt(example_path, janus_code):
     """Test function to run geometry optimization using the example file provided."""
     example_file_path = example_path / "submit_geomopt.py"
-    command = ["verdi", "run", example_file_path, "janus@localhost"]
+    command = [
+        "verdi",
+        "run",
+        example_file_path,
+        f"{janus_code.label}@{janus_code.computer.label}",
+    ]
 
     # Execute the command
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.stderr == ""
     assert result.returncode == 0
+    assert "results from calculation:" in result.stdout
+    assert "'traj_file': <SinglefileData: uuid:" in result.stdout
+    assert "'final_structure': <StructureData: uuid:" in result.stdout

--- a/tests/calculations/test_md.py
+++ b/tests/calculations/test_md.py
@@ -201,12 +201,23 @@ def test_run_md(model_folder, structure_folder, janus_code):
     )  # check
 
 
-def test_example_md(example_path):
+def test_example_md(example_path, janus_code):
     """Test function to run MD calculation using the example file provided."""
     example_file_path = example_path / "submit_md.py"
-    command = ["verdi", "run", example_file_path, "janus@localhost"]
-
+    command = [
+        "verdi",
+        "run",
+        example_file_path,
+        f"{janus_code.label}@{janus_code.computer.label}",
+        "--md_dict_str",
+        "{'steps': 10, 'traj-every': 1}",
+    ]
     # Execute the command
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.stderr == ""
     assert result.returncode == 0
+    assert "results from calculation:" in result.stdout
+    assert "'results_dict': <Dict: uuid:" in result.stdout
+    assert "'traj_output': <TrajectoryData: uuid:" in result.stdout
+    assert "'final_structure': <StructureData: uuid" in result.stdout
+    assert "'stats_file': <SinglefileData: uuid" in result.stdout

--- a/tests/calculations/test_singlepoint.py
+++ b/tests/calculations/test_singlepoint.py
@@ -147,12 +147,20 @@ def test_run_sp(model_folder, janus_code):
     assert obtained_res["info"]["mace_stress"][0] == pytest.approx(-0.005816546985101)
 
 
-def test_example(example_path):
+def test_example(example_path, janus_code):
     """Test function to run singlepoint calculation using the example file provided."""
     example_file_path = example_path / "submit_singlepoint.py"
-    command = ["verdi", "run", example_file_path, "janus@localhost"]
+    command = [
+        "verdi",
+        "run",
+        example_file_path,
+        f"{janus_code.label}@{janus_code.computer.label}",
+    ]
 
     # Execute the command
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.stderr == ""
     assert result.returncode == 0
+    assert "results from calculation:" in result.stdout
+    assert "'results_dict': <Dict: uuid:" in result.stdout
+    assert "'xyz_output': <SinglefileData: uuid:" in result.stdout


### PR DESCRIPTION
Resolves #165

Similar to changes made in #162, this fixes tests for submitting calculations.

As noted in #165, the fixtures we currently use are deprecated, but that can be done separately, as swapping them out seems non-trivial (see #166).