### PR TITLE
Apply ruff to descriptors 

### DIFF
--- a/aiida_mlip/calculations/descriptors.py
+++ b/aiida_mlip/calculations/descriptors.py
@@ -63,7 +63,6 @@ class Descriptors(Singlepoint):  # numpydoc ignore=PR01
             "parser_name"
         ].default = "mlip.descriptors_parser"
 
-    # pylint: disable=too-many-locals
     def prepare_for_submission(
         self, folder: aiida.common.folders.Folder
     ) -> datastructures.CalcInfo:

--- a/examples/calculations/submit_descriptors.py
+++ b/examples/calculations/submit_descriptors.py
@@ -1,11 +1,10 @@
 """Example code for submitting descriptors calculation."""
 
-import click
-
 from aiida.common import NotExistent
 from aiida.engine import run_get_node
 from aiida.orm import Bool, Str, load_code
 from aiida.plugins import CalculationFactory
+import click
 
 from aiida_mlip.helpers.help_load import load_model, load_structure
 

--- a/examples/calculations/submit_descriptors.py
+++ b/examples/calculations/submit_descriptors.py
@@ -106,7 +106,6 @@ def cli(
     calc_per_element,
     calc_per_atom,
 ) -> None:
-    # pylint: disable=too-many-arguments
     """Click interface."""
     try:
         code = load_code(codelabel)
@@ -131,4 +130,4 @@ def cli(
 
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    cli()

--- a/tests/calculations/test_descriptors.py
+++ b/tests/calculations/test_descriptors.py
@@ -2,20 +2,18 @@
 
 import subprocess
 
-from ase.build import bulk
-import pytest
-
 from aiida.common import datastructures
 from aiida.engine import run
 from aiida.orm import Bool, Str, StructureData
 from aiida.plugins import CalculationFactory
+from ase.build import bulk
+import pytest
 
 from aiida_mlip.data.model import ModelData
 
 
 def test_descriptors(fixture_sandbox, generate_calc_job, janus_code, model_folder):
-    """Test generating descriptors calculation job"""
-
+    """Test generating descriptors calculation job."""
     entry_point_name = "mlip.descriptors"
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
@@ -69,7 +67,7 @@ def test_descriptors(fixture_sandbox, generate_calc_job, janus_code, model_folde
 
 
 def test_run_descriptors(model_folder, janus_code):
-    """Test running descriptors calculation"""
+    """Test running descriptors calculation."""
     model_file = model_folder / "mace_mp_small.model"
     inputs = {
         "metadata": {"options": {"resources": {"num_machines": 1}}},


### PR DESCRIPTION
Descriptors files were consistent with the old pre-commit, so was not checked properly against ruff. 