### PR TITLE
Fix workgraph

### DIFF
--- a/aiida_mlip/workflows/ht_workgraph.py
+++ b/aiida_mlip/workflows/ht_workgraph.py
@@ -74,7 +74,7 @@ def build_ht_calc(
             name=f"calc_{file.stem}",
             **calc_inputs,
         )
-        calc_task.set_context({final_struct_key: f"structs.{file.stem}"})
+        calc_task.set_context({f"structs.{file.stem}": final_struct_key})
 
     if structure is None:
         raise FileNotFoundError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ aiida-core = "^2.6"
 ase = "^3.23.0"
 voluptuous = "^0.14"
 janus-core = "^0.6.6"
-aiida-workgraph = {extras = ["widget"], version = "^0.4.5"}
+aiida-workgraph = {extras = ["widget"], version = "0.4.10"}
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}


### PR DESCRIPTION
Rerunning tests on main currently fails.

This updates workgraph (not to the newest version, as that has more breaking changes), which includes swapping the order of setting the context key and value. 