### PR TITLE
Update janus-core and drop Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.9','3.10','3.11','3.12']
-        aiida-version: ['stable']
+        python-version: ["3.10", "3.11", "3.12"]
+        aiida-version: ["stable"]
 
     services:
       postgres:
@@ -46,6 +46,7 @@ jobs:
       run: |
         poetry env use ${{ matrix.python-version }}
         poetry install --with dev
+        poetry run pip install mace-torch
 
     - name: Run test suite
 

--- a/aiida_mlip/calculations/geomopt.py
+++ b/aiida_mlip/calculations/geomopt.py
@@ -111,7 +111,14 @@ class GeomOpt(Singlepoint):  # numpydoc ignore=PR01
         calcinfo = super().prepare_for_submission(folder)
         codeinfo = calcinfo.codes_info[0]
 
-        geom_opt_cmdline = {"traj": self.inputs.traj.value}
+        minimize_kwargs = (
+            f"{{'traj_kwargs': {{'filename': '{self.inputs.traj.value}'}}}}"
+        )
+
+        geom_opt_cmdline = {
+            "minimize-kwargs": minimize_kwargs,
+            "write-traj": True,
+        }
         if "opt_kwargs" in self.inputs:
             opt_kwargs = self.inputs.opt_kwargs.get_dict()
             geom_opt_cmdline["opt-kwargs"] = opt_kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ documentation = "https://stfc.github.io/aiida-mlip/"
 "Source" = "https://github.com/aiidateam/aiida-mlip"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.10, <3.13"
 aiida-core = "^2.6"
-ase = "^3.23.0"
+ase = "^3.24.0"
 voluptuous = "^0.14"
-janus-core = "^0.6.6"
+janus-core = "^0.7.5"
 aiida-workgraph = {extras = ["widget"], version = "0.4.10"}
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/calculations/test_geomopt.py
+++ b/tests/calculations/test_geomopt.py
@@ -42,8 +42,9 @@ def test_geomopt(fixture_sandbox, generate_calc_job, janus_code, model_folder):
         "aiida-results.xyz",
         "--calc-kwargs",
         "{'default_dtype': 'float64', 'model': 'mlff.model'}",
-        "--traj",
-        "aiida-traj.xyz",
+        "--minimize-kwargs",
+        "{'traj_kwargs': {'filename': 'aiida-traj.xyz'}}",
+        "--write-traj",
     ]
 
     retrieve_list = [


### PR DESCRIPTION
Updates `janus-core`, which requires dropping Python 3.9, as well as minimum ASE requirement, although this was already used in practice.

We're not affected by the changes janus's output directory, since we specify files by hand, but the changes to how the `geomopt` trajectory is saved needed fixing.

`janus-core` also no longer comes with `mace`, leading to errors unless it is installed.

The output from the tests did not make that at all clear, so something to look into in future is catching and raising this more clearly (although perhaps it's hidden in the AiiDA output files, which are harder to see in tests).