### PR TITLE
Fix building documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    container: sphinxdoc/sphinx
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #195

Remove unnecessary sphinx container, which seems to be missing required compilers.

Removing this seemed to fix things on my branch, and in general the installation of `phonopy` is fine in other CI workflows, so this is the obvious difference. 