### PR TITLE
Add ipykernel dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ source = "https://github.com/aiidateam/aiida-mlip"
 [dependency-groups]
 dev = [
     "coverage[toml]<8.0.0,>=7.4.1",
+    "ipykernel>=6.30.0",
     "pgtest<2.0.0,>=1.3.2",
     "pytest<9.0,>=8.0",
     "pytest-cov<5.0.0,>=4.1.0",


### PR DESCRIPTION
Adds `ipykernel` to `dev` dependency group, so it should be automatically installed on `uv sync` etc, as we have for `janus-core`.