### PR TITLE
Fix setting version

### DIFF
--- a/aiida_mlip/__init__.py
+++ b/aiida_mlip/__init__.py
@@ -2,4 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.1"
+from importlib.metadata import version
+
+__version__ = version("aiida-mlip")


### PR DESCRIPTION
Resolves #207

Removes hardcoded version in `__init__.py`, as we have done in `janus-core`.