### PR TITLE
Update janus-core

### DIFF
--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -120,13 +120,13 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
             "arch",
             valid_type=Str,
             required=False,
-            help="Mlip architecture to use for calculation, defaults to mace",
+            help="MLIP architecture to use for calculation",
         )
         spec.input(
             "model",
             valid_type=ModelData,
             required=False,
-            help="Mlip model used for calculation",
+            help="MLIP model used for calculation",
         )
         spec.input(
             "struct",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "aiida-core<3,>=2.7",
     "ase<4.0,>=3.24",
     "voluptuous<1,>=0.15.2",
-    "janus-core<0.8,>=0.7.5",
+    "janus-core<0.9,>=0.8.3",
     "aiida-workgraph<0.7, >=0.6.0",
 ]
 


### PR DESCRIPTION
Resolves #181

This doesn't seem to break anything.

The main difference would have been `model` rather than `model_path`, but that's still only deprecated, and in fact we still set that via `calc_kwargs`(to be updated soon, separately.)

We also claimed to have default model of `mace`, but we already validate that a model is either explicitly set or in the config file, so I don't think that changes here.

Similarly, `janus-core` used to have `mace_mp` as the default architecture, but we already check it's set, so I don't believe this was ever the case for `aiida-mlip`.