### PR TITLE
Fix docstring typos and old type hints

### DIFF
--- a/aiida_mlip/calculations/base.py
+++ b/aiida_mlip/calculations/base.py
@@ -95,7 +95,7 @@ class BaseJanus(CalcJob):  # numpydoc ignore=PR01
     -------
     define(spec: CalcJobProcessSpec) -> None:
         Define the process specification, its inputs, outputs and exit codes.
-    validate_inputs(value: dict, port_namespace: PortNamespace) -> Optional[str]:
+    validate_inputs(value: dict, port_namespace: PortNamespace) -> str | None:
         Check if the inputs are valid.
     prepare_for_submission(folder: Folder) -> CalcInfo:
         Create the input files for the `CalcJob`.

--- a/aiida_mlip/calculations/singlepoint.py
+++ b/aiida_mlip/calculations/singlepoint.py
@@ -24,7 +24,7 @@ class Singlepoint(BaseJanus):  # numpydoc ignore=PR01
     -------
     define(spec: CalcJobProcessSpec) -> None:
         Define the process specification, its inputs, outputs and exit codes.
-    validate_inputs(value: dict, port_namespace: PortNamespace) -> Optional[str]:
+    validate_inputs(value: dict, port_namespace: PortNamespace) -> str | None:
         Check if the inputs are valid.
     prepare_for_submission(folder: Folder) -> CalcInfo:
         Create the input files for the `CalcJob`.

--- a/aiida_mlip/calculations/train.py
+++ b/aiida_mlip/calculations/train.py
@@ -74,7 +74,7 @@ class Train(CalcJob):  # numpydoc ignore=PR01
     -------
     define(spec: CalcJobProcessSpec) -> None:
         Define the process specification, its inputs, outputs and exit codes.
-    validate_inputs(value: dict, port_namespace: PortNamespace) -> Optional[str]:
+    validate_inputs(value: dict, port_namespace: PortNamespace) -> str | None:
         Check if the inputs are valid.
     prepare_for_submission(folder: Folder) -> CalcInfo:
         Create the input files for the `CalcJob`.

--- a/aiida_mlip/data/config.py
+++ b/aiida_mlip/data/config.py
@@ -17,10 +17,10 @@ class JanusConfigfile(SinglefileData):
 
     Parameters
     ----------
-    file : Union[str, Path]
+    file : str | Path
         Absolute path to the file.
-    filename : Optional[str], optional
-        Name to be used for the file (defaults to the name of provided file).
+    filename : str | None
+        Name to be used for the file. Default is the name of provided file.
 
     Attributes
     ----------
@@ -51,14 +51,14 @@ class JanusConfigfile(SinglefileData):
         **kwargs: Any,
     ) -> None:
         """
-        Initialize the ModelData object.
+        Initialize the JanusConfigfile object.
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Absolute path to the file.
-        filename : Optional[str], optional
-            Name to be used for the file (defaults to the name of provided file).
+        filename : str | None
+            Name to be used for the file. Defaults is the name of provided file.
 
         Other Parameters
         ----------------
@@ -96,10 +96,10 @@ class JanusConfigfile(SinglefileData):
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Absolute path to the file.
-        filename : Optional[str], optional
-            Name to be used for the file (defaults to the name of provided file).
+        filename : str | None
+            Name to be used for the file. Default is the name of provided file.
 
         Other Parameters
         ----------------

--- a/aiida_mlip/data/model.py
+++ b/aiida_mlip/data/model.py
@@ -16,12 +16,12 @@ class ModelData(SinglefileData):
 
     Parameters
     ----------
-    file : Union[str, Path]
+    file : str | Path
         Absolute path to the file.
     architecture : str
         Architecture of the mlip model.
-    filename : Optional[str], optional
-        Name to be used for the file (defaults to the name of provided file).
+    filename : str | None
+        Name to be used for the file. Default is the name of provided file.
 
     Attributes
     ----------
@@ -52,7 +52,7 @@ class ModelData(SinglefileData):
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Path to the file for which hash needs to be calculated.
 
         Returns
@@ -81,12 +81,12 @@ class ModelData(SinglefileData):
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Absolute path to the file.
-        architecture : [str]
+        architecture : str
             Architecture of the mlip model.
-        filename : Optional[str], optional
-            Name to be used for the file (defaults to the name of provided file).
+        filename : str | None
+            Name to be used for the file. Default is the name of provided file.
 
         Other Parameters
         ----------------
@@ -108,12 +108,12 @@ class ModelData(SinglefileData):
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Absolute path to the file.
-        filename : Optional[str], optional
-            Name to be used for the file (defaults to the name of provided file).
-        architecture : Optional[str], optional
-            Architecture of the mlip model.
+        filename : str | None
+            Name to be used for the file. Defaults is the name of provided file.
+        architecture : str | None
+            Architecture of the mlip model. Default is `None`.
 
         Other Parameters
         ----------------
@@ -138,12 +138,12 @@ class ModelData(SinglefileData):
 
         Parameters
         ----------
-        file : Union[str, Path]
+        file : str | Path
             Path to the file.
-        architecture : [str]
+        architecture : str
             Architecture of the mlip model.
-        filename : Optional[str], optional
-            Name to be used for the file (defaults to the name of provided file).
+        filename : str | None
+            Name to be used for the file. Default is the name of provided file.
 
         Returns
         -------
@@ -169,16 +169,16 @@ class ModelData(SinglefileData):
         ----------
         uri : str
             URI of the file to download.
-        architecture : [str]
+        architecture : str
             Architecture of the mlip model.
-        filename : Optional[str], optional
+        filename : str | None
             Name to be used for the file defaults to tmp_file.model.
-        cache_dir : Optional[Union[str, Path]], optional
-            Path to the folder where the file has to be saved
-            (defaults to "~/.cache/mlips/").
-        keep_file : Optional[bool], optional
+        cache_dir : str | Path | None
+            Path to the folder where the file has to be saved. Defaults is
+            "~/.cache/mlips/".
+        keep_file : bool | None
             True to keep the downloaded model, even if there are duplicates.
-            (default: False, the file is deleted and only saved in the database).
+            Default is `False`, so the file is deleted and only saved in the database.
 
         Returns
         -------

--- a/aiida_mlip/helpers/converters.py
+++ b/aiida_mlip/helpers/converters.py
@@ -40,7 +40,7 @@ def xyz_to_aiida_traj(
 
     Parameters
     ----------
-    traj_file : Union[str, Path]
+    traj_file : str | Path
         The path to the XYZ file.
 
     Returns

--- a/aiida_mlip/helpers/help_load.py
+++ b/aiida_mlip/helpers/help_load.py
@@ -27,11 +27,11 @@ def load_model(
 
     Parameters
     ----------
-    model : Optional[Union[str, Path]]
+    model : str | Path | None
         Model file path or a URI for downloading the model or None to use the default.
     architecture : str
         The architecture of the model.
-    cache_dir : Optional[Union[str, Path]]
+    cache_dir : str | Path | None
         Directory where to save the dowloaded model.
 
     Returns
@@ -64,7 +64,7 @@ def load_structure(struct: str | Path | int | None = None) -> StructureData:
 
     Parameters
     ----------
-    struct : Optional[Union[str, Path, int]]
+    struct : str | Path | int | None
         The input value representing either a path to a structure file, a node PK,
         or None.
 

--- a/aiida_mlip/workflows/ht_workgraph.py
+++ b/aiida_mlip/workflows/ht_workgraph.py
@@ -30,9 +30,9 @@ def build_ht_calc(
 
     Parameters
     ----------
-    calc : Union[CalcJob, Callable, WorkChain, WorkGraph]
+    calc : CalcJob | Callable | WorkChain | WorkGraph
         Calculation to be performed on all structures.
-    folder : Union[Path, str, Str]
+    folder : Path | str | Str
         Path to the folder containing input structure files.
     calc_inputs : dict
         Dictionary of inputs, shared by all the calculations. Must not contain


### PR DESCRIPTION
Mostly updating docstring type hints that weren't updated when the actual type hints (`Optional`/`Union`) were automatically converted, and a few typos/changes for consistency.