### PR TITLE
Update profile setup in computer setup notebook

### DIFF
--- a/examples/tutorials/aiida_setup/setup-external-computer.ipynb
+++ b/examples/tutorials/aiida_setup/setup-external-computer.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "<ul>\n",
     "        <li>AiiDA installed locally</li>\n",
-    "        <li>A profile setup</li>\n",
+    "        <li>A profile set up</li>\n",
     "        <li>Quantum Espresso installed on the remote computer</li>\n",
     "</ul>"
    ]


### PR DESCRIPTION
Remove profile name `-p scarf` from `setup-external-computer.ipynb` when we create a profile. Better for first time user and overall user experience