### PR TITLE
Pin RabbitMQ to last AiiDA-supported version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:latest
+        image: rabbitmq:3.8.14
         ports:
           - 5672:5672
 


### PR DESCRIPTION
Later versions introduced default timeouts. The default timeout of 30 mins is actually fine for CI, but the AiiDA warnings about it are distracting noise if they show up in test logs.

https://aiida.readthedocs.io/projects/aiida-core/en/latest/installation/troubleshooting.html#rabbitmq-incompatibility

(As discussed in https://github.com/stfc/aiida-mlip/pull/270. Thanks @ElliottKasoar for hunting down the docs page!)

Alternatively we can disable the warning by some other means such as `verdi config set warnings.rabbitmq_version False`. According to the AiiDA docs, that is necessary _even if you increase the timeout_.

The simplest option for now seems to be a pin. It's only in the CI so doesn't impact users.