### PR TITLE
Upgrade to aiida-core 2.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 keywords = ["aiida", "plugin"]
 
 dependencies = [
-    "aiida-core==2.7.1",
+    "aiida-core~=2.7.4",
     "ase<4.0,>=3.24",
     "voluptuous<1,>=0.15.2",
     "janus-core<0.9,>=0.8.3",


### PR DESCRIPTION
aiida-core v2.7.4 includes upstream bug fix aiidateam/aiida-core#7486 resolving issue stfc/aiida-mlip#262. The datetime serialization in the Querybuilder was not handled correctly.

CI passes on my fork see https://github.com/agoscinski/aiida-mlip/actions/runs/30156792551